### PR TITLE
Feature: SectionMessage, Badge 추가

### DIFF
--- a/docs/wds_component_guide.md
+++ b/docs/wds_component_guide.md
@@ -1655,3 +1655,207 @@ knob 이동 | 좌우로 각각 독립적 이동 가능
 동일값 허용 | `start == end` 상황 허용
 interaction 표시 | hover/pressed 시 32x32 영역 표시
 division 단위 | `divisions`가 설정된 경우 해당 단위로만 이동
+
+
+## SectionMessage
+
+> 특정 섹션이나 영역 내에서 중요한 정보나 피드백을 전달하는 메시지입니다. 사용자가 필요한 행동을 취할 수 있도록 돕습니다.
+
+SectionMessage는 아래 속성으로 이루어집니다.
+
+속성 | Type | 비고
+--- | --- | --- 
+message | `String` | 메시지에 표시될 텍스트 내용
+leadingIcon | `WdsIcon?` | 선택사항인 앞쪽 아이콘
+variant | `WdsSectionMessageVariant` | 메시지의 표시 형태 (normal, highlight, warning)
+
+### SectionMessage - variant
+
+정해진 Variant만 사용할 수 있습니다.
+
+- `normal`: 기본 정보 전달 형태
+- `highlight`: 긍정적인 정보나 성공 상태 표시
+- `warning`: 주의가 필요한 정보나 경고 상태 표시
+
+### SectionMessage - 고정된 속성
+
+모든 SectionMessage는 동일한 레이아웃 속성을 갖습니다.
+
+속성 | 값 | 비고
+--- | --- | ---
+padding | `EdgeInsets.all(16)` | 모든 variant 고정
+iconSize | 16x16 | 아이콘 크기 고정
+iconPosition | leading | 아이콘 위치 고정
+iconSpacing | 4px | 아이콘과 텍스트 사이 간격
+
+### SectionMessage - variant별 속성
+
+variant에 따라 색상이 달라집니다.
+
+속성 | normal | highlight | warning
+--- | --- | --- | ---
+backgroundColor | `WdsColors.backgroundAlternative` | `WdsColors.blue50` | `WdsColors.orange50`
+textColor | `WdsColors.textNeutral` | `WdsColors.statusPositive` | `WdsColors.statusCautionaty`
+iconColor | `WdsColors.neutral500` | `WdsColors.primary` | `WdsColors.statusCautionaty`
+
+### SectionMessage - 생성 방법
+
+named constructor로 생성할 수 있습니다.
+
+``` dart
+// 기본 정보 메시지
+WdsSectionMessage.normal(
+  message: '정보를 확인해주세요',
+  leadingIcon: WdsIcon.info,
+)
+
+// 긍정적 메시지
+WdsSectionMessage.highlight(
+  message: '작업이 완료되었습니다',
+  leadingIcon: WdsIcon.checkCircle,
+)
+
+// 경고 메시지
+WdsSectionMessage.warning(
+  message: '주의가 필요한 사항입니다',
+  leadingIcon: WdsIcon.warning,
+)
+```
+
+### SectionMessage - 구현 세부사항
+
+- **borderRadius**: `WdsRadius.v8` (8px)
+- **Row spacing**: 4px (아이콘과 텍스트 사이)
+- **MainAxisSize**: `MainAxisSize.min` (콘텐츠 크기에 맞춤)
+- **Typography**: `WdsTypography.body14NormalMedium`
+
+## Badge
+
+> 정보의 개수를 강조하기 위해 사용합니다. 장바구니 아이템, 알림 등 개수에 대한 표기가 필요한 경우에 활용합니다. 중요도에 맞게 CTA/Primary 컬러를 사용합니다.
+
+Badge는 아래 속성으로 이루어집니다.
+
+속성 | Type | 비고
+--- | --- | --- 
+count | `int` | 표시할 개수 (0은 표시하지 않음)
+targetIcon | `Widget` | Badge가 붙을 대상 아이콘 위젯
+
+### Badge - 고정된 속성
+
+모든 Badge는 동일한 시각적 속성을 갖습니다.
+
+속성 | 값 | 비고
+--- | --- | ---
+backgroundColor | `WdsColors.primary` | 고정
+borderRadius | `WdsRadius.full` | 완전한 원형
+padding | `EdgeInsets.fromLTRB(4, 2, 4, 2)` | 고정
+typography | `WdsTypography.caption9SemiBold` | 9px, Pretendard, w600
+textColor | `WdsColors.white` | 고정
+letterSpacing | 0.03px | 고정
+lineHeight | 128% | 고정
+
+### Badge - 개수 표시 규칙
+
+- 0은 표시하지 않음
+- 1부터 99까지 숫자로 표시
+- 100부터는 "99+"로 표시
+
+### Badge - 위치 및 크기
+
+Badge는 항상 대상 아이콘의 오른쪽 아래에 위치합니다.
+
+속성 | 값 | 비고
+--- | --- | ---
+targetIconSize | 24x24 | 대상 아이콘 크기 (0,0 ~ 23,23)
+stackSize | 24x24 | 원본 아이콘 크기 유지 (overflow 허용)
+badgePosition | 동적 계산 | digitCount에 따라 left 위치 조정
+interactionArea | 24x24 | 터치 영역 (아이콘 크기와 동일)
+
+### Badge - 사용 방법
+
+Extension을 통해 아이콘에 Badge를 추가할 수 있습니다.
+
+``` dart
+// 기본 사용법
+WdsIcon.cart.build().addBadge(count: 4);
+
+// Extension 구현
+extension WdsBadgeExtension on Widget {
+  Widget addBadge({
+    required int count,
+  }) {
+    if (count <= 0) {
+      return this;
+    }
+
+    return Stack(
+      children: [
+        this,
+        Positioned(
+          right: 0,
+          top: 0,
+          child: WdsBadge(count: count),
+        ),
+      ],
+    );
+  }
+}
+```
+
+### Badge - 크기별 차이
+
+개수에 따라 Badge 크기와 위치가 달라집니다.
+
+개수 범위 | 크기 | 위치 조정 | 비고
+--- | --- | --- | ---
+1 | 16x16 | left: 12px | 한 자리 수 (특별 처리)
+2-9 | 16x16 | left: 7px | 한 자리 수
+10-99 | 20x16 | left: 2px | 두 자리 수 (가로 확장)
+100+ | 24x16 | left: 2px | "99+" 표시 (최대 크기)
+
+### Badge - Overflow 허용 방식
+
+Badge가 원본 아이콘 크기를 유지하면서 overflow를 허용합니다.
+
+``` dart
+Stack(
+  clipBehavior: Clip.none, // overflow 허용
+  children: [
+    originalWidget, // 원본 위젯 그대로 유지 (24x24)
+    Positioned(
+      left: 19.5, // Badge 중앙이 (19.5, 19.5)에 위치
+      top: 19.5,  // 아이콘 24x24 기준 오른쪽 아래 중앙
+      child: WdsBadge(count: count),
+    ),
+  ],
+)
+```
+
+### Badge - 위치 계산
+
+- **아이콘 크기**: 24x24 (픽셀 0,0 ~ 23,23)
+- **Stack 크기**: 24x24 (원본 아이콘 크기 유지)
+- **Badge 위치**: `left: 12 - ((digitCount - 1) * 5), top: 12`
+- **digitCount**: 1자리=1, 2자리=2, 3자리 이상=2 (99+)
+- **Overflow**: Badge가 아이콘 영역을 벗어나도 표시됨
+
+### Badge - 위치 계산 공식
+
+``` dart
+int digitCount = count.toString().length;
+if (digitCount > 2) {
+  digitCount = 2; // 99+는 2자리로 처리
+}
+
+Positioned(
+  left: 12 - ((digitCount - 1) * 5), // 동적 위치 계산
+  top: 12, // 고정 상단 위치
+  child: WdsBadge(count: count),
+)
+```
+
+### Badge - 레이아웃 영향
+
+- **Row/Column**: 아이콘 크기(24x24)만큼만 공간 차지
+- **AppBar**: 높이가 늘어나지 않음
+- **Overflow**: Badge가 아이콘 영역을 벗어나도 정상 표시

--- a/packages/components/lib/src/badge/wds_badge.dart
+++ b/packages/components/lib/src/badge/wds_badge.dart
@@ -1,0 +1,102 @@
+part of '../../wds_components.dart';
+
+/// 정보의 개수를 강조하기 위해 사용하는 Badge 컴포넌트
+///
+/// 장바구니 아이템, 알림 등 개수에 대한 표기가 필요한 경우에 활용합니다.
+class WdsBadge extends StatelessWidget {
+  const WdsBadge({
+    required this.count,
+    super.key,
+  });
+
+  /// 표시할 개수 (0은 표시하지 않음)
+  final int count;
+
+  @override
+  Widget build(BuildContext context) {
+    if (count <= 0) {
+      return const SizedBox.shrink();
+    }
+
+    final displayText = _getDisplayText(count);
+
+    final text = Text(
+      displayText,
+      style: const TextStyle(
+        color: WdsColors.white,
+        letterSpacing: 0.03,
+        height: 1.28, // 128%
+        fontWeight: FontWeight.w600,
+        fontFamily: WdsTypography.fontFamily,
+        fontSize: 9,
+      ),
+      textAlign: TextAlign.center,
+    );
+
+    return DecoratedBox(
+      decoration: const BoxDecoration(
+        color: WdsColors.primary,
+        borderRadius: BorderRadius.all(Radius.circular(WdsRadius.full)),
+      ),
+      child: Padding(
+        padding: const EdgeInsets.fromLTRB(4, 2, 4, 2),
+        child: Builder(
+          builder: (context) {
+            if (displayText.length == 1) {
+              if (count == 1) {
+                return Padding(
+                  padding: const EdgeInsets.symmetric(horizontal: 2),
+                  child: text,
+                );
+              }
+
+              return Padding(
+                padding: const EdgeInsets.symmetric(horizontal: 1),
+                child: text,
+              );
+            }
+
+            return text;
+          },
+        ),
+      ),
+    );
+  }
+
+  String _getDisplayText(int count) {
+    if (count <= 99) return count.toString();
+    return '99+';
+  }
+}
+
+/// Widget에 Badge를 추가하는 Extension
+extension WdsBadgeExtension on Widget {
+  /// 아이콘에 Badge를 추가합니다
+  Widget addBadge({
+    required int count,
+  }) {
+    if (count <= 0) {
+      return this;
+    }
+
+    int digitCount = count.toString().length;
+    if (digitCount > 2) {
+      digitCount = 2;
+    }
+
+    return Stack(
+      clipBehavior: Clip.none,
+      children: [
+        // 원본 위젯 그대로 유지 (24x24)
+        this,
+
+        /// Badge 위치 조정 - 아이콘 기준 오른쪽 아래 중앙
+        Positioned(
+          left: 12 - ((digitCount - 1) * 5),
+          top: 12,
+          child: WdsBadge(count: count),
+        ),
+      ],
+    );
+  }
+}

--- a/packages/components/lib/src/section_message/wds_section_message.dart
+++ b/packages/components/lib/src/section_message/wds_section_message.dart
@@ -1,0 +1,108 @@
+part of '../../wds_components.dart';
+
+/// SectionMessage variant enum
+enum WdsSectionMessageVariant {
+  /// 기본 정보 전달 형태
+  normal,
+
+  /// 긍정적인 정보나 성공 상태 표시
+  highlight,
+
+  /// 주의가 필요한 정보나 경고 상태 표시
+  warning,
+}
+
+class _SectionMessageStyleByVariant {
+  const _SectionMessageStyleByVariant._();
+
+  static ({
+    Color background,
+    Color text,
+    Color icon,
+  }) of(WdsSectionMessageVariant variant) {
+    return switch (variant) {
+      WdsSectionMessageVariant.normal => (
+          background: WdsColors.backgroundAlternative,
+          text: WdsColors.textNeutral,
+          icon: WdsColors.neutral500,
+        ),
+      WdsSectionMessageVariant.highlight => (
+          background: WdsColors.blue50,
+          text: WdsColors.statusPositive,
+          icon: WdsColors.primary,
+        ),
+      WdsSectionMessageVariant.warning => (
+          background: WdsColors.orange50,
+          text: WdsColors.statusCautionaty,
+          icon: WdsColors.statusCautionaty,
+        ),
+    };
+  }
+}
+
+/// 특정 섹션이나 영역 내에서 중요한 정보나 피드백을 전달하는 메시지 컴포넌트
+///
+/// 사용자가 필요한 행동을 취할 수 있도록 돕습니다.
+class WdsSectionMessage extends StatelessWidget {
+  /// 기본 정보 메시지
+  const WdsSectionMessage.normal({
+    required this.leadingIcon,
+    required this.message,
+    super.key,
+  }) : variant = WdsSectionMessageVariant.normal;
+
+  /// 긍정적 메시지
+  const WdsSectionMessage.highlight({
+    required this.leadingIcon,
+    required this.message,
+    super.key,
+  }) : variant = WdsSectionMessageVariant.highlight;
+
+  /// 경고 메시지
+  const WdsSectionMessage.warning({
+    required this.leadingIcon,
+    required this.message,
+    super.key,
+  }) : variant = WdsSectionMessageVariant.warning;
+
+  /// 메시지에 표시될 텍스트 내용
+  final String message;
+
+  /// 선택사항인 앞쪽 아이콘
+  final WdsIcon leadingIcon;
+
+  /// SectionMessage variant
+  final WdsSectionMessageVariant variant;
+
+  @override
+  Widget build(BuildContext context) {
+    final style = _SectionMessageStyleByVariant.of(variant);
+
+    return DecoratedBox(
+      decoration: BoxDecoration(
+        color: style.background,
+        borderRadius: const BorderRadius.all(Radius.circular(8)),
+      ),
+      child: Padding(
+        padding: const EdgeInsets.all(16), // 모든 variant 고정
+        child: Row(
+          mainAxisSize: MainAxisSize.min,
+          spacing: 4,
+          children: [
+            leadingIcon.build(
+              width: 16, // 16x16 고정
+              height: 16,
+              color: style.icon,
+            ),
+            Text(
+              message,
+              style: WdsTypography.body14NormalMedium.copyWith(
+                color: style.text,
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/packages/components/lib/wds_components.dart
+++ b/packages/components/lib/wds_components.dart
@@ -33,3 +33,5 @@ part 'src/text_field/wds_search_field.dart';
 part 'src/text_field/wds_text_field.dart';
 part 'src/toast/wds_toast.dart';
 part 'src/tooltip/wds_tooltip.dart';
+part 'src/section_message/wds_section_message.dart';
+part 'src/badge/wds_badge.dart';

--- a/packages/widgetbook/lib/main.directories.g.dart
+++ b/packages/widgetbook/lib/main.directories.g.dart
@@ -12,6 +12,8 @@
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:wds_widgetbook/src/component/action_area_use_case.dart'
     as _wds_widgetbook_src_component_action_area_use_case;
+import 'package:wds_widgetbook/src/component/badge_use_case.dart'
+    as _wds_widgetbook_src_component_badge_use_case;
 import 'package:wds_widgetbook/src/component/bottom_navigation_use_case.dart'
     as _wds_widgetbook_src_component_bottom_navigation_use_case;
 import 'package:wds_widgetbook/src/component/button_use_case.dart'
@@ -34,6 +36,8 @@ import 'package:wds_widgetbook/src/component/radio_use_case.dart'
     as _wds_widgetbook_src_component_radio_use_case;
 import 'package:wds_widgetbook/src/component/search_field_use_case.dart'
     as _wds_widgetbook_src_component_search_field_use_case;
+import 'package:wds_widgetbook/src/component/section_message_use_case.dart'
+    as _wds_widgetbook_src_component_section_message_use_case;
 import 'package:wds_widgetbook/src/component/select_use_case.dart'
     as _wds_widgetbook_src_component_select_use_case;
 import 'package:wds_widgetbook/src/component/slider_use_case.dart'
@@ -77,6 +81,14 @@ final directories = <_widgetbook.WidgetbookNode>[
           name: 'ActionArea',
           builder: _wds_widgetbook_src_component_action_area_use_case
               .buildWdsFixedActionAreaUseCase,
+        ),
+      ),
+      _widgetbook.WidgetbookLeafComponent(
+        name: 'Badge',
+        useCase: _widgetbook.WidgetbookUseCase(
+          name: 'Badge',
+          builder:
+              _wds_widgetbook_src_component_badge_use_case.buildWdsBadgeUseCase,
         ),
       ),
       _widgetbook.WidgetbookLeafComponent(
@@ -164,6 +176,14 @@ final directories = <_widgetbook.WidgetbookNode>[
           name: 'SearchField',
           builder: _wds_widgetbook_src_component_search_field_use_case
               .buildWdsSearchFieldUseCase,
+        ),
+      ),
+      _widgetbook.WidgetbookLeafComponent(
+        name: 'SectionMessage',
+        useCase: _widgetbook.WidgetbookUseCase(
+          name: 'SectionMessage',
+          builder: _wds_widgetbook_src_component_section_message_use_case
+              .buildWdsSectionMessageUseCase,
         ),
       ),
       _widgetbook.WidgetbookLeafComponent(

--- a/packages/widgetbook/lib/src/component/badge_use_case.dart
+++ b/packages/widgetbook/lib/src/component/badge_use_case.dart
@@ -1,0 +1,97 @@
+import 'package:wds_widgetbook/src/widgetbook_components/widgetbook_components.dart';
+import 'package:widgetbook/widgetbook.dart';
+import 'package:widgetbook_annotation/widgetbook_annotation.dart' as widgetbook;
+
+@widgetbook.UseCase(
+  name: 'Badge',
+  type: Badge,
+  path: '[component]/',
+)
+Widget buildWdsBadgeUseCase(BuildContext context) {
+  return WidgetbookPageLayout(
+    title: 'Badge',
+    description:
+        '정보의 개수를 강조하기 위해 사용합니다. 장바구니 아이템, 알림 등 개수에 대한 표기가 필요한 경우에 활용합니다.',
+    children: [
+      _buildPlaygroundSection(context),
+      const SizedBox(height: 32),
+      _buildDemonstrationSection(context),
+    ],
+  );
+}
+
+Widget _buildPlaygroundSection(BuildContext context) {
+  final count = context.knobs.int.input(
+    label: 'count',
+    description: 'Badge에 표기할 개수를 입력해 주세요.\n\u2022 \'0\'은 표기되지 않아요',
+    initialValue: 6,
+  );
+
+  final icon = context.knobs.object.dropdown<WdsIcon>(
+    label: 'icon',
+    description: 'Badge가 붙을 아이콘을 선택하세요',
+    initialOption: WdsIcon.cart,
+    options: WdsIcon.values,
+    labelBuilder: (v) => v.name,
+  );
+
+  return WidgetbookPlayground(
+    child: icon.build().addBadge(count: count),
+  );
+}
+
+Widget _buildDemonstrationSection(BuildContext context) {
+  return WidgetbookSection(
+    title: 'Badge',
+    children: [
+      WidgetbookSubsection(
+        title: 'range',
+        labels: ['0', '1-9', '10-99', '100+'],
+        content: Row(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            WdsIcon.cart.build().addBadge(count: 0),
+            const SizedBox(width: 16),
+            WdsIcon.cart.build().addBadge(count: 3),
+            const SizedBox(width: 16),
+            WdsIcon.cart.build().addBadge(count: 42),
+            const SizedBox(width: 16),
+            WdsIcon.cart.build().addBadge(count: 150),
+          ],
+        ),
+      ),
+      const SizedBox(height: 32),
+      WidgetbookSubsection(
+        title: 'icons',
+        labels: ['cart', 'settings', 'call', 'comment'],
+        content: Row(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            WdsIcon.cart.build().addBadge(count: 5),
+            const SizedBox(width: 16),
+            WdsIcon.settings.build().addBadge(count: 12),
+            const SizedBox(width: 16),
+            WdsIcon.call.build().addBadge(count: 99),
+            const SizedBox(width: 16),
+            WdsIcon.comment.build().addBadge(count: 999),
+          ],
+        ),
+      ),
+      const SizedBox(height: 32),
+      const WidgetbookSubsection(
+        title: 'count',
+        labels: ['1', '42', '99+'],
+        content: Row(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            WdsBadge(count: 1),
+            SizedBox(width: 16),
+            WdsBadge(count: 42),
+            SizedBox(width: 16),
+            WdsBadge(count: 150),
+          ],
+        ),
+      ),
+    ],
+  );
+}

--- a/packages/widgetbook/lib/src/component/section_message_use_case.dart
+++ b/packages/widgetbook/lib/src/component/section_message_use_case.dart
@@ -1,0 +1,160 @@
+import 'package:wds_widgetbook/src/widgetbook_components/widgetbook_components.dart';
+import 'package:widgetbook/widgetbook.dart';
+import 'package:widgetbook_annotation/widgetbook_annotation.dart' as widgetbook;
+
+@widgetbook.UseCase(
+  name: 'SectionMessage',
+  type: SectionMessage,
+  path: '[component]/',
+)
+Widget buildWdsSectionMessageUseCase(BuildContext context) {
+  return WidgetbookPageLayout(
+    title: 'SectionMessage',
+    description:
+        '특정 섹션이나 영역 내에서 중요한 정보나 피드백을 전달하는 메시지입니다. 사용자가 필요한 행동을 취할 수 있도록 돕습니다.',
+    children: [
+      _buildPlaygroundSection(context),
+      const SizedBox(height: 32),
+      _buildDemonstrationSection(context),
+    ],
+  );
+}
+
+Widget _buildPlaygroundSection(BuildContext context) {
+  final variant = context.knobs.object.dropdown<WdsSectionMessageVariant>(
+    label: 'variant',
+    description: '메시지의 표시 형태를 선택하세요',
+    options: WdsSectionMessageVariant.values,
+    initialOption: WdsSectionMessageVariant.normal,
+    labelBuilder: (v) => v.name,
+  );
+
+  final message = context.knobs.string(
+    label: 'message',
+    description: 'SectionMessage에 표시될 메시지를 입력해 주세요',
+    initialValue: '정보를 확인해주세요',
+  );
+
+  final hasIcon = context.knobs.boolean(
+    label: 'hasIcon',
+    description: '아이콘을 표시할지 선택하세요',
+  );
+
+  final icon = context.knobs.object.dropdown<WdsIcon>(
+    label: 'icon',
+    initialOption: WdsIcon.info,
+    options: WdsIcon.values,
+    labelBuilder: (v) => v.name,
+  );
+
+  return WidgetbookPlayground(
+    info: [
+      'variant: ${variant.name}',
+      'message: "$message"',
+      'hasIcon: $hasIcon',
+      if (hasIcon) 'icon: ${icon.name}',
+      'padding: EdgeInsets.all(16)',
+      'iconSize: 16x16',
+      'iconSpacing: 4px',
+      'textStyle: body14NormalMedium',
+      _getVariantInfo(variant),
+    ],
+    child: _buildSectionMessage(
+      variant: variant,
+      message: message,
+      hasIcon: hasIcon,
+      icon: icon,
+    ),
+  );
+}
+
+String _getVariantInfo(WdsSectionMessageVariant variant) {
+  return switch (variant) {
+    WdsSectionMessageVariant.normal =>
+      'backgroundColor: backgroundAlternative, textColor: textNeutral, iconColor: neutral500',
+    WdsSectionMessageVariant.highlight =>
+      'backgroundColor: statusPositive, textColor: statusPositive, iconColor: primary',
+    WdsSectionMessageVariant.warning =>
+      'backgroundColor: orange50, textColor: statusCautionaty, iconColor: statusCautionaty',
+  };
+}
+
+Widget _buildSectionMessage({
+  required WdsSectionMessageVariant variant,
+  required String message,
+  required bool hasIcon,
+  required WdsIcon icon,
+}) {
+  final leadingIcon = hasIcon ? icon : WdsIcon.blank;
+
+  return switch (variant) {
+    WdsSectionMessageVariant.normal => WdsSectionMessage.normal(
+        message: message,
+        leadingIcon: leadingIcon,
+      ),
+    WdsSectionMessageVariant.highlight => WdsSectionMessage.highlight(
+        message: message,
+        leadingIcon: leadingIcon,
+      ),
+    WdsSectionMessageVariant.warning => WdsSectionMessage.warning(
+        message: message,
+        leadingIcon: leadingIcon,
+      ),
+  };
+}
+
+Widget _buildDemonstrationSection(BuildContext context) {
+  return const WidgetbookSection(
+    title: 'SectionMessage',
+    children: [
+      WidgetbookSubsection(
+        title: 'variant',
+        labels: ['normal', 'highlight', 'warning'],
+        content: Column(
+          crossAxisAlignment: CrossAxisAlignment.stretch,
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            WdsSectionMessage.normal(
+              message: '기본 정보를 확인해주세요',
+              leadingIcon: WdsIcon.info,
+            ),
+            SizedBox(height: 16),
+            WdsSectionMessage.highlight(
+              message: '상품을 게시글에 태그했어요',
+              leadingIcon: WdsIcon.productTag,
+            ),
+            SizedBox(height: 16),
+            WdsSectionMessage.warning(
+              message: '장바구니에 상품이 없어요',
+              leadingIcon: WdsIcon.cart,
+            ),
+          ],
+        ),
+      ),
+      SizedBox(height: 32),
+      WidgetbookSubsection(
+        title: 'only message',
+        labels: ['normal', 'highlight', 'warning'],
+        content: Column(
+          crossAxisAlignment: CrossAxisAlignment.stretch,
+          mainAxisSize: MainAxisSize.min,
+          spacing: 16,
+          children: [
+            WdsSectionMessage.normal(
+              leadingIcon: WdsIcon.blank,
+              message: '아이콘 없이 표시되는 메시지입니다',
+            ),
+            WdsSectionMessage.highlight(
+              leadingIcon: WdsIcon.blank,
+              message: '성공 메시지입니다',
+            ),
+            WdsSectionMessage.warning(
+              leadingIcon: WdsIcon.blank,
+              message: '경고 메시지입니다',
+            ),
+          ],
+        ),
+      ),
+    ],
+  );
+}

--- a/packages/widgetbook/lib/src/widgetbook_components/widgetbook_components.dart
+++ b/packages/widgetbook/lib/src/widgetbook_components/widgetbook_components.dart
@@ -91,3 +91,9 @@ class Tooltip {}
 
 /// 컴포넌트 path 관리를 위한 클래스
 class Divider {}
+
+/// 컴포넌트 path 관리를 위한 클래스
+class SectionMessage {}
+
+/// 컴포넌트 path 관리를 위한 클래스
+class Badge {}


### PR DESCRIPTION
## ✅ 주요 변경 요약

### 1. **새로운 UI 컴포넌트 구현**
* `WdsBadge` 컴포넌트 추가
 * 아이콘 위에 카운트 배지를 표시하는 컴포넌트
 * 카운트 값에 따른 동적 크기 조정 및 위치 지정
 * 아이콘에 쉽게 연결할 수 있는 확장 메서드 포함
* `WdsSectionMessage` 컴포넌트 구현
 * 섹션 내 중요한 메시지 표시용 컴포넌트
 * normal, highlight, warning의 세 가지 변형 지원
 * 각각 고정된 레이아웃 및 색상 속성 제공

---

### 2. **Widgetbook 통합 및 데모**
* 새로운 컴포넌트 등록 및 유스케이스 구현
 * Badge 및 SectionMessage 컴포넌트를 Widgetbook에 등록
 * 각각에 대한 상호작용 플레이그라운드 및 시연 섹션 포함
* 네비게이션 지원 확장
 * `widgetbook_components.dart`에 Badge 및 SectionMessage용 경로 관리 클래스 추가
 * Widgetbook 네비게이션 구조 내 완전한 통합

---

### 3. **포괄적인 문서화**
* 컴포넌트 가이드 확장
 * `docs/wds_component_guide.md`에 Badge 및 SectionMessage의 속성, 변형, 레이아웃, 사용법 설명 추가
 * 배지의 상세한 위치 지정 로직 및 샘플 코드 포함

---

### 4. **컴포넌트 라이브러리 통합**
* 새로운 컴포넌트 Export
 * `wds_components.dart`에서 새로운 컴포넌트 파일 export
 * 코드베이스 전반에서 사용 가능하도록 라이브러리 통합

---

## 📋 **주요 변경 포인트**
* **카운트 표시를 위한 Badge 컴포넌트로 알림 및 상태 표시 기능 확장**
* **중요한 메시지 전달을 위한 SectionMessage로 사용자 커뮤니케이션 개선**
* **상호작용 가능한 Widgetbook 데모로 컴포넌트 탐색 및 테스트 지원**
* **상세한 문서화로 개발자 가이드라인 및 사용성 확보**

---

## ☑️ **마이그레이션/배포 체크리스트**
* `WdsBadge` 컴포넌트의 동적 크기 조정이 다양한 카운트 값에서 올바르게 작동하는지 확인
* Badge 확장 메서드가 다양한 아이콘에 적절히 연결되는지 테스트
* `WdsSectionMessage`의 세 가지 변형(normal, highlight, warning)이 올바른 색상과 스타일로 표시되는지 검증
* Widgetbook에서 두 컴포넌트의 플레이그라운드가 상호작용과 함께 정상 작동하는지 확인
* Badge의 위치 지정 로직이 문서화된 대로 정확히 구현되었는지 테스트
* SectionMessage 변형이 다양한 콘텐츠 길이에서 적절한 레이아웃을 유지하는지 검증
* 새로운 컴포넌트들이 `wds_components.dart`에서 정상적으로 export되고 import 가능한지 확인
* 문서화된 사용 예제가 실제 컴포넌트 구현과 정확히 일치하는지 테스트
* Widgetbook 네비게이션에서 새 컴포넌트 섹션이 올바르게 접근 가능한지 확인