### PR TITLE
Feat: Thumbnail 추가

### DIFF
--- a/docs/wds_component_guide.md
+++ b/docs/wds_component_guide.md
@@ -2133,3 +2133,115 @@ Stack(
   ],
 )
 ```
+
+## Thumbnail
+
+일정한 비율의 이미지로 콘텐츠를 미리 보여줍니다. 네트워크 이미지와 에셋 이미지를 모두 지원하며, 캐싱 기능을 통해 성능을 최적화합니다.
+
+Thumbnail은 아래 속성으로 이루어집니다.
+
+속성 | Type | 비고
+--- | --- | --- 
+imagePath | `String` | 이미지 경로 (URL 또는 에셋 경로)
+size | `WdsThumbnailSize` | 썸네일 크기 (xxs, xs, sm, md, lg, xl, xxl)
+hasRadius | `bool` | 모서리 둥글기 적용 여부
+
+### Thumbnail - 자동 감지
+
+이미지 경로에 따라 자동으로 네트워크/에셋을 구분합니다.
+
+- **네트워크 이미지**: `http://` 또는 `https://`로 시작하는 URL
+- **에셋 이미지**: `assets/`로 시작하는 경로 또는 상대 경로
+
+### Thumbnail - size
+
+px 단위로 이루어집니다. 모든 크기는 정사각형이며, xl만 179x250의 직사각형입니다.
+
+속성 | size | 비고
+--- | --- | ---
+xxs | Size(64, 64) | 가장 작은 크기
+xs | Size(74, 74) | 작은 크기
+sm | Size(90, 90) | 작은-중간 크기
+md | Size(106, 106) | 중간 크기
+lg | Size(140, 140) | 큰 크기
+xl | Size(179, 250) | 가로형 직사각형
+xxl | Size(200, 200) | 가장 큰 정사각형
+
+e.g. enum
+``` dart
+enum WdsThumbnailSize {
+  xxs(size: Size(64, 64)),
+  xs(size: Size(74, 74)),
+  sm(size: Size(90, 90)),
+  md(size: Size(106, 106)),
+  lg(size: Size(140, 140)),
+  xl(size: Size(179, 250)),
+  xxl(size: Size(200, 200));
+
+  const WdsThumbnailSize({
+    required this.size,
+  });
+
+  final Size size;
+}
+```
+
+### Thumbnail - radius
+
+모서리 둥글기 설정입니다.
+
+속성 | 값 | 비고
+--- | --- | ---
+true | `BorderRadius.all(Radius.circular(WdsRadius.xs))` | 둥근 모서리 적용
+false | `null` | 직각 모서리
+
+### Thumbnail - 네트워크 이미지 처리
+
+네트워크 이미지는 `cached_network_image` 패키지를 사용하여 캐싱됩니다.
+
+- **원본 URL**: 입력된 URL을 그대로 사용
+- **에러 처리**: 로딩 실패 시 고정 placeholder 표시
+
+### Thumbnail - placeholder
+
+이미지 로딩 중에 표시되는 고정 위젯입니다.
+
+속성 | 값 | 비고
+--- | --- | ---
+placeholder | `WdsColors.coolNeutral100` 배경의 회색 사각형 | 고정, 변경 불가
+
+### Thumbnail - 생성 방법
+
+단일 생성자로 네트워크/에셋 이미지를 모두 처리합니다.
+
+``` dart
+// 네트워크 이미지 (자동 감지)
+WdsThumbnail(
+  imagePath: 'https://example.com/image.jpg',
+  size: WdsThumbnailSize.md,
+  hasRadius: true,
+)
+
+// 에셋 이미지 (자동 감지)
+WdsThumbnail(
+  imagePath: 'assets/images/thumbnail.png',
+  size: WdsThumbnailSize.lg,
+  hasRadius: false,
+)
+```
+
+### Thumbnail - 에러 처리
+
+이미지 로딩 실패 시 처리 방식입니다.
+
+- **네트워크 이미지**: 로딩 실패 시 고정 placeholder 표시
+- **에셋 이미지**: 에셋 로딩 실패 시 고정 placeholder 표시
+- **모든 경우**: 에러 발생 시 기본 placeholder (회색 배경) 표시
+
+### Thumbnail - 성능 최적화
+
+- **캐싱**: `cached_network_image`를 통한 자동 캐싱
+- **메모리 관리**: 이미지 크기에 따른 적절한 해상도 선택
+- **로딩 상태**: placeholder를 통한 부드러운 로딩 경험
+- **const 최적화**: 가능한 모든 위젯에 `const` 키워드 적용
+

--- a/packages/components/lib/src/thumbnail/wds_thumbnail.dart
+++ b/packages/components/lib/src/thumbnail/wds_thumbnail.dart
@@ -1,0 +1,112 @@
+part of '../../wds_components.dart';
+
+/// 썸네일 크기를 정의하는 열거형
+enum WdsThumbnailSize {
+  xxs(size: Size(64, 64)),
+  xs(size: Size(74, 74)),
+  sm(size: Size(90, 90)),
+  md(size: Size(106, 106)),
+  lg(size: Size(140, 140)),
+  xl(size: Size(179, 250)),
+  xxl(size: Size(200, 200));
+
+  const WdsThumbnailSize({
+    required this.size,
+  });
+
+  final Size size;
+}
+
+/// 네트워크 이미지와 에셋 이미지를 지원하는 썸네일 컴포넌트
+class WdsThumbnail extends StatelessWidget {
+  /// 썸네일 생성자 (네트워크/에셋 자동 감지)
+  const WdsThumbnail({
+    required this.imagePath,
+    required this.size,
+    this.hasRadius = false,
+    super.key,
+  });
+
+  /// 이미지 경로 (URL 또는 에셋 경로)
+  final String imagePath;
+
+  /// 썸네일 크기
+  final WdsThumbnailSize size;
+
+  /// 모서리 둥글기 적용 여부
+  final bool hasRadius;
+
+  @override
+  Widget build(BuildContext context) {
+    final borderRadius = hasRadius
+        ? const BorderRadius.all(Radius.circular(WdsRadius.xs))
+        : null;
+
+    return RepaintBoundary(
+      child: SizedBox.fromSize(
+        size: size.size,
+        child: ClipRRect(
+          borderRadius: borderRadius ?? BorderRadius.zero,
+          child: _isNetworkImage(imagePath)
+              ? _buildNetworkImage()
+              : _buildAssetImage(),
+        ),
+      ),
+    );
+  }
+
+  /// 네트워크 이미지인지 확인
+  bool _isNetworkImage(String path) {
+    return path.startsWith('http://') || path.startsWith('https://');
+  }
+
+  /// 에셋 이미지 빌드
+  Widget _buildAssetImage() {
+    return Image.asset(
+      imagePath,
+      width: size.size.width,
+      height: size.size.height,
+      fit: BoxFit.cover,
+      errorBuilder: (context, error, stackTrace) {
+        return _buildPlaceholder();
+      },
+      frameBuilder: (context, child, frame, wasSynchronouslyLoaded) {
+        if (wasSynchronouslyLoaded) return child;
+        return AnimatedOpacity(
+          opacity: frame == null ? 0 : 1,
+          duration: const Duration(milliseconds: 200),
+          child: child,
+        );
+      },
+    );
+  }
+
+  /// 네트워크 이미지 빌드
+  Widget _buildNetworkImage() {
+    return CachedNetworkImage(
+      imageUrl: imagePath,
+      width: size.size.width,
+      height: size.size.height,
+      fit: BoxFit.cover,
+      placeholder: (context, url) => _buildPlaceholder(),
+      errorWidget: (context, url, error) => _buildPlaceholder(),
+      imageBuilder: (context, imageProvider) {
+        return DecoratedBox(
+          decoration: BoxDecoration(
+            image: DecorationImage(
+              image: imageProvider,
+              fit: BoxFit.cover,
+            ),
+          ),
+        );
+      },
+    );
+  }
+
+  /// 고정 placeholder 빌드 (Container 대신 const 위젯 사용)
+  Widget _buildPlaceholder() {
+    return const ColoredBox(
+      color: WdsColors.coolNeutral100,
+    );
+  }
+}

--- a/packages/components/lib/wds_components.dart
+++ b/packages/components/lib/wds_components.dart
@@ -1,3 +1,4 @@
+import 'package:cached_network_image/cached_network_image.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart'
     show
@@ -35,5 +36,6 @@ part 'src/switch/wds_switch.dart';
 part 'src/tab/wds_tab.dart';
 part 'src/text_field/wds_search_field.dart';
 part 'src/text_field/wds_text_field.dart';
+part 'src/thumbnail/wds_thumbnail.dart';
 part 'src/toast/wds_toast.dart';
 part 'src/tooltip/wds_tooltip.dart';

--- a/packages/components/pubspec.yaml
+++ b/packages/components/pubspec.yaml
@@ -10,6 +10,7 @@ dependencies:
     sdk: flutter
   wds_foundation:
     path: ../foundation
+  cached_network_image: ^3.4.1
 
 dev_dependencies:
   flutter_lints: ^5.0.0

--- a/packages/widgetbook/lib/main.directories.g.dart
+++ b/packages/widgetbook/lib/main.directories.g.dart
@@ -58,6 +58,8 @@ import 'package:wds_widgetbook/src/component/text_button_use_case.dart'
     as _wds_widgetbook_src_component_text_button_use_case;
 import 'package:wds_widgetbook/src/component/text_field_use_case.dart'
     as _wds_widgetbook_src_component_text_field_use_case;
+import 'package:wds_widgetbook/src/component/thumbnail_use_case.dart'
+    as _wds_widgetbook_src_component_wds_thumbnail_use_case;
 import 'package:wds_widgetbook/src/component/toast_use_case.dart'
     as _wds_widgetbook_src_component_toast_use_case;
 import 'package:wds_widgetbook/src/component/tooltip_use_case.dart'
@@ -268,6 +270,14 @@ final directories = <_widgetbook.WidgetbookNode>[
           name: 'TextField',
           builder: _wds_widgetbook_src_component_text_field_use_case
               .buildWdsTextFieldUseCase,
+        ),
+      ),
+      _widgetbook.WidgetbookLeafComponent(
+        name: 'Thumbnail',
+        useCase: _widgetbook.WidgetbookUseCase(
+          name: 'Thumbnail',
+          builder: _wds_widgetbook_src_component_wds_thumbnail_use_case
+              .buildThumbnailUseCase,
         ),
       ),
       _widgetbook.WidgetbookLeafComponent(

--- a/packages/widgetbook/lib/src/component/sheet_use_case.dart
+++ b/packages/widgetbook/lib/src/component/sheet_use_case.dart
@@ -3,7 +3,11 @@ import 'package:wds_widgetbook/src/widgetbook_components/widgetbook_components.d
 import 'package:widgetbook/widgetbook.dart';
 import 'package:widgetbook_annotation/widgetbook_annotation.dart';
 
-@UseCase(name: 'Sheet', type: WdsSheet, path: '[component]/')
+@UseCase(
+  name: 'Sheet',
+  type: Sheet,
+  path: '[component]/',
+)
 Widget buildWdsSheetUseCase(BuildContext context) {
   return WidgetbookPageLayout(
     title: 'Sheet',

--- a/packages/widgetbook/lib/src/component/thumbnail_use_case.dart
+++ b/packages/widgetbook/lib/src/component/thumbnail_use_case.dart
@@ -1,0 +1,227 @@
+import 'package:wds_widgetbook/src/widgetbook_components/widgetbook_components.dart';
+import 'package:widgetbook/widgetbook.dart';
+import 'package:widgetbook_annotation/widgetbook_annotation.dart';
+
+@UseCase(
+  name: 'Thumbnail',
+  type: Thumbnail,
+  path: '[component]/',
+)
+Widget buildThumbnailUseCase(BuildContext context) {
+  return WidgetbookPageLayout(
+    title: 'Thumbnail',
+    description: '일정한 비율의 이미지로 콘텐츠를 미리 보여줍니다.',
+    children: [
+      _buildPlaygroundSection(context),
+      const SizedBox(height: 32),
+      _buildDemonstrationSection(context),
+    ],
+  );
+}
+
+Widget _buildPlaygroundSection(BuildContext context) {
+  final size = context.knobs.object.dropdown(
+    label: 'size',
+    options: WdsThumbnailSize.values,
+    labelBuilder: (value) => value.name,
+    initialOption: WdsThumbnailSize.md,
+  );
+
+  final hasRadius = context.knobs.boolean(
+    label: 'radius 유무',
+    initialValue: true,
+  );
+
+  final imagePath = context.knobs.string(
+    label: 'image URL',
+    initialValue: 'https://picsum.photos/400/300',
+  );
+
+  return WidgetbookPlayground(
+    info: [
+      'Size: ${size.name} (${size.size.width}x${size.size.height})',
+      'Radius: $hasRadius',
+      'Image URL: $imagePath',
+      'Type: ${imagePath.startsWith('http') ? 'Network' : 'Asset'}',
+    ],
+    child: SizedBox(
+      height: 200,
+      child: Center(
+        child: WdsThumbnail(
+          imagePath: imagePath,
+          size: size,
+          hasRadius: hasRadius,
+        ),
+      ),
+    ),
+  );
+}
+
+Widget _buildDemonstrationSection(BuildContext context) {
+  return const WidgetbookSection(
+    title: 'Thumbnail',
+    children: [
+      WidgetbookSubsection(
+        title: 'variant',
+        labels: ['Network', 'Asset'],
+        content: Row(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            WdsThumbnail(
+              imagePath: 'https://picsum.photos/200/200?random=1',
+              size: WdsThumbnailSize.lg,
+              hasRadius: true,
+            ),
+            SizedBox(width: 24),
+            WdsThumbnail(
+              imagePath: 'assets/images/placeholder.png',
+              size: WdsThumbnailSize.lg,
+              hasRadius: true,
+            ),
+          ],
+        ),
+      ),
+
+      WidgetbookSubsection(
+        title: 'size',
+        labels: ['xxs', 'xs', 'sm', 'md', 'lg', 'xl', 'xxl'],
+        content: Wrap(
+          spacing: 16,
+          runSpacing: 16,
+          children: [
+            Column(
+              spacing: 8,
+              children: [
+                WdsThumbnail(
+                  imagePath: 'https://picsum.photos/64/64?random=1',
+                  size: WdsThumbnailSize.xxs,
+                  hasRadius: true,
+                ),
+                Text('xxs (64x64)'),
+              ],
+            ),
+            Column(
+              spacing: 8,
+              children: [
+                WdsThumbnail(
+                  imagePath: 'https://picsum.photos/74/74?random=2',
+                  size: WdsThumbnailSize.xs,
+                  hasRadius: true,
+                ),
+                Text('xs (74x74)'),
+              ],
+            ),
+            Column(
+              spacing: 8,
+              children: [
+                WdsThumbnail(
+                  imagePath: 'https://picsum.photos/90/90?random=3',
+                  size: WdsThumbnailSize.sm,
+                  hasRadius: true,
+                ),
+                Text('sm (90x90)'),
+              ],
+            ),
+            Column(
+              spacing: 8,
+              children: [
+                WdsThumbnail(
+                  imagePath: 'https://picsum.photos/106/106?random=4',
+                  size: WdsThumbnailSize.md,
+                  hasRadius: true,
+                ),
+                Text('md (106x106)'),
+              ],
+            ),
+            Column(
+              spacing: 8,
+              children: [
+                WdsThumbnail(
+                  imagePath: 'https://picsum.photos/140/140?random=5',
+                  size: WdsThumbnailSize.lg,
+                  hasRadius: true,
+                ),
+                Text('lg (140x140)'),
+              ],
+            ),
+            Column(
+              spacing: 8,
+              children: [
+                WdsThumbnail(
+                  imagePath: 'https://picsum.photos/179/250?random=6',
+                  size: WdsThumbnailSize.xl,
+                  hasRadius: true,
+                ),
+                Text('xl (179x250)'),
+              ],
+            ),
+            Column(
+              spacing: 8,
+              children: [
+                WdsThumbnail(
+                  imagePath: 'https://picsum.photos/200/200?random=7',
+                  size: WdsThumbnailSize.xxl,
+                  hasRadius: true,
+                ),
+                Text('xxl (200x200)'),
+              ],
+            ),
+          ],
+        ),
+      ),
+
+      /// Radius
+      WidgetbookSubsection(
+        title: 'radius',
+        labels: ['true', 'false'],
+        content: Row(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            WdsThumbnail(
+              imagePath: 'https://picsum.photos/120/120?random=11',
+              size: WdsThumbnailSize.md,
+              hasRadius: true,
+            ),
+            SizedBox(width: 24),
+            WdsThumbnail(
+              imagePath: 'https://picsum.photos/120/120?random=12',
+              size: WdsThumbnailSize.md,
+            ),
+          ],
+        ),
+      ),
+
+      /// State
+      WidgetbookSubsection(
+        title: 'state',
+        labels: ['loading', 'error', 'success'],
+        content: Wrap(
+          spacing: 16,
+          children: [
+            /// 로딩 상태 (빠른 네트워크로 인해 보이지 않을 수 있음)
+            WdsThumbnail(
+              imagePath: 'https://httpbin.org/delay/2',
+              size: WdsThumbnailSize.md,
+              hasRadius: true,
+            ),
+
+            /// 에러 상태 (존재하지 않는 URL)
+            WdsThumbnail(
+              imagePath:
+                  'https://invalid-url-that-does-not-exist.com/image.jpg',
+              size: WdsThumbnailSize.md,
+              hasRadius: true,
+            ),
+
+            /// 성공 상태
+            WdsThumbnail(
+              imagePath: 'https://picsum.photos/120/120?random=13',
+              size: WdsThumbnailSize.md,
+              hasRadius: true,
+            ),
+          ],
+        ),
+      ),
+    ],
+  );
+}

--- a/packages/widgetbook/lib/src/widgetbook_components/widgetbook_components.dart
+++ b/packages/widgetbook/lib/src/widgetbook_components/widgetbook_components.dart
@@ -103,3 +103,6 @@ class Badge {}
 
 /// 컴포넌트 path 관리를 위한 클래스
 class Sheet {}
+
+/// 컴포넌트 path 관리를 위한 클래스
+class Thumbnail {}


### PR DESCRIPTION
## ✅ 주요 변경 요약

### 1. **새로운 Thumbnail 컴포넌트 구현**
* `WdsThumbnail` 위젯 추가
 * 네트워크 및 에셋 이미지 모두 지원하는 표준화된 썸네일 표시 컴포넌트
 * `WdsThumbnailSize` 열거형을 통한 다양한 사전 정의 크기 지원
 * 선택적 border radius, placeholder 및 에러 처리 기능
 * `cached_network_image` 패키지를 활용한 이미지 캐싱 등 성능 최적화
* 의존성 추가
 * 네트워크 이미지 캐싱 지원을 위해 `pubspec.yaml`에 `cached_network_image` 의존성 추가

---

### 2. **포괄적인 문서화**
* Thumbnail 컴포넌트 가이드 추가
 * `wds_component_guide.md`에 새로운 Thumbnail 컴포넌트 섹션 추가
 * API, 사용법, 지원 기능, 동작에 대한 상세 설명
 * 개발자를 위한 완전한 사용 가이드 제공

---

### 3. **컴포넌트 라이브러리 통합**
* 메인 라이브러리 등록
 * `wds_components.dart`에 새로운 `WdsThumbnail` 등록
 * `cached_network_image`에 대한 필요한 import 추가
* 경로 관리 지원
 * 컴포넌트 경로 관리를 위한 `Thumbnail` 마커 클래스 추가

---

### 4. **Widgetbook 통합 및 유스케이스**
* 상호작용 데모 구현
 * WdsThumbnail을 위한 새로운 widgetbook 유스케이스 파일 추가
 * 모든 지원 크기, 상태(로딩, 에러, 성공), radius 옵션에 대한 플레이그라운드 컨트롤 및 시연 제공
* Widgetbook 디렉토리 등록
 * 상호작용 탐색을 위해 UI에 표시되도록 widgetbook 디렉토리 구조에 새로운 썸네일 유스케이스 등록
