### PR TITLE
Feature: Heading 추가

### DIFF
--- a/docs/wds_component_guide.md
+++ b/docs/wds_component_guide.md
@@ -2245,3 +2245,265 @@ WdsThumbnail(
 - **로딩 상태**: placeholder를 통한 부드러운 로딩 경험
 - **const 최적화**: 가능한 모든 위젯에 `const` 키워드 적용
 
+## Tag
+
+상품의 상태, 배송 일정, 카테고리 등 짧고 핵심적인 정보를 시각적으로 강조하기 위해 사용됩니다.
+
+
+**공통요소**
+- padding: horizontal 4px
+- borderRadius: `WdsRadius.xs` (4px)
+- typography: `WdsTypography.caption10Medium
+- height: 18px, 고정 높이
+
+### Tag - variant
+
+- normal
+- filled
+
+아래는 기본값
+
+**normal**
+- color: `WdsColors.textNeutral`
+- backgroundColor: `WdsColors.neutral50`
+
+**filled**
+- color: `WdsColors.white`
+- backgroundColor: `WdsColors.primary`
+
+다만 색상이 바뀔 수 있습니다.
+
+## ItemCard
+
+> 상품 정보를 집약적으로 전달하는 카드 컴포넌트입니다. 상품의 썸네일, 브랜드명, 상품명, 가격, 평점, 좋아요 등의 정보를 포함하여 상세 페이지로 유도하는 목적을 가집니다.
+
+ItemCard는 아래 속성으로 이루어집니다.
+
+속성 | Type | 비고
+--- | --- | --- 
+onLiked | `VoidCallback` | 좋아요 버튼이 눌렸을 때 콜백
+thumbnailImageUrl | `String` | 썸네일 이미지 URL
+brandName | `String` | 브랜드명 (xs 크기에서는 표시되지 않음)
+productName | `String` | 상품명
+lensType | `String` | 렌즈 유형
+diameter | `String` | 직경
+originalPrice | `double` | 정가
+salePrice | `double` | 판매가
+rating | `double` | 평점 (0.0 ~ 5.0)
+reviewCount | `int` | 리뷰 개수
+likeCount | `int` | 좋아요 개수
+hasLiked | `bool` | 좋아요 상태 (기본값: false)
+tags | `List<WdsTag>` | 태그 목록 (기본값: 빈 리스트)
+
+### ItemCard - size
+
+px 단위로 이루어집니다. 크기에 따라 레이아웃이 세로형(xl, lg)과 가로형(md, xs)으로 구분됩니다.
+
+속성 | layout | thumbnail size | 비고
+--- | --- | --- | ---
+xl | 세로형 | WdsThumbnailSize.xl | 가장 큰 크기, 세로 배치
+lg | 세로형 | WdsThumbnailSize.lg | 큰 크기, 세로 배치
+md | 가로형 | WdsThumbnailSize.md | 중간 크기, 가로 배치
+xs | 가로형 | WdsThumbnailSize.xs | 가장 작은 크기, 가로 배치
+
+e.g. enum
+``` dart
+enum WdsItemCardSize {
+  xl,
+  lg,
+  md,
+  xs;
+}
+```
+
+### ItemCard - layout
+
+크기에 따라 두 가지 레이아웃으로 구분됩니다.
+
+**세로형 레이아웃 (xl, lg)**
+- 썸네일이 상단에 위치
+- 상품 정보가 썸네일 하단에 세로로 배치
+- 브랜드명, 상품명, 렌즈 정보, 가격, 태그, 평점/좋아요 정보 순서로 배치
+
+**가로형 레이아웃 (md, xs)**
+- 썸네일이 좌측에 위치
+- 상품 정보가 썸네일 우측에 세로로 배치
+- md: 브랜드명 포함, xs: 브랜드명 제외
+
+### ItemCard - thumbnail
+
+각 크기별로 적절한 썸네일 크기를 사용합니다.
+
+속성 | thumbnail size | hasRadius | 비고
+--- | --- | --- | ---
+xl | WdsThumbnailSize.xl | false | 둥근 모서리 없음
+lg | WdsThumbnailSize.lg | true | 둥근 모서리 적용
+md | WdsThumbnailSize.md | true | 둥근 모서리 적용
+xs | WdsThumbnailSize.xs | true | 둥근 모서리 적용
+
+### ItemCard - typography
+
+크기별로 다른 타이포그래피를 사용합니다.
+
+**브랜드명**
+- xl/lg: `WdsTypography.body13NormalRegular`, `WdsColors.textNeutral`
+- md: `WdsTypography.caption12Regular`, `WdsColors.textNeutral`
+- xs: 표시되지 않음
+
+**상품명**
+- xl: `WdsTypography.body13NormalRegular`, `WdsColors.textNormal`, 최대 2줄
+- lg: `WdsTypography.body13NormalRegular`, `WdsColors.textNormal`, 최대 1줄
+- md: `WdsTypography.body13NormalRegular`, `WdsColors.textNormal`, 최대 1줄
+- xs: `WdsTypography.caption12Medium`, `WdsColors.textNormal`, 최대 1줄
+
+**렌즈 정보**
+- xl/lg/md: `WdsTypography.caption12Regular`, `WdsColors.textAlternative`
+- xs: `WdsTypography.caption11Regular`, `WdsColors.textAlternative`
+
+**가격 정보**
+- xl/lg: `WdsTypography.body15NormalBold`, `WdsColors.textNormal`
+- md: `WdsTypography.body13NormalBold`, `WdsColors.textNormal`
+- xs: `WdsTypography.caption12Bold`, `WdsColors.textNormal`
+
+### ItemCard - price display
+
+할인이 있는 경우와 없는 경우로 구분하여 표시합니다.
+
+**할인 없는 경우**
+- 판매가만 표시
+
+**할인이 있는 경우**
+- xl: 정가(취소선) + 할인율 + 판매가를 세로로 배치
+- lg/md/xs: 할인율 + 판매가를 가로로 배치
+
+할인율은 `WdsColors.secondary` 색상으로 강조 표시됩니다.
+
+### ItemCard - tags
+
+상품에 관련된 태그들을 표시합니다.
+
+속성 | 값 | 비고
+--- | --- | ---
+spacing | 2px | 태그 간 간격
+maxCount | 제한 없음 | 권장: 2개 이하
+position | 가격 정보 하단 | 세로형 레이아웃에서만 표시
+
+### ItemCard - rating & like info
+
+평점과 좋아요 정보를 표시합니다.
+
+**평점 정보**
+- 아이콘: `WdsIcon.starFilled` (10x10px, `WdsColors.neutral200`)
+- 텍스트: `"평점(리뷰수)"` 형식
+- typography: `WdsTypography.caption11Regular`, `WdsColors.textAssistive`
+
+**좋아요 정보**
+- 아이콘: `WdsNavigationIcon.like` (10x10px, `WdsColors.neutral200`)
+- 텍스트: 좋아요 개수
+- typography: `WdsTypography.caption11Regular`, `WdsColors.textAssistive`
+
+### ItemCard - like button
+
+좋아요 버튼의 위치와 형태가 크기에 따라 다릅니다.
+
+속성 | xl/lg | md | xs
+--- | --- | --- | ---
+position | 우측 상단 | 우측 하단 | 우측 하단
+layout | 아이콘만 | 아이콘만 | 아이콘 + 개수 (세로 배치)
+size | 18x18px | 18x18px | 18x18px
+color (active) | `WdsColors.secondary` | `WdsColors.secondary` | `WdsColors.secondary`
+color (inactive) | `WdsColors.neutral200` | `WdsColors.neutral200` | `WdsColors.neutral200`
+
+### ItemCard - spacing
+
+크기별로 다른 간격을 사용합니다.
+
+속성 | xl | lg | md | xs
+--- | --- | --- | --- | ---
+thumbnail-content | 10px | 10px | 16px | 12px
+element spacing | 4px | 4px | 4px | 2px
+horizontal padding | 12px | 0px | 0px | 0px
+
+### ItemCard - 생성 방법
+
+named constructor로 생성할 수 있습니다.
+
+``` dart
+// 세로형 레이아웃 (xl)
+WdsItemCard.xl(
+  onLiked: () => print('좋아요'),
+  thumbnailImageUrl: 'https://example.com/image.jpg',
+  brandName: '브랜드명',
+  productName: '상품명',
+  lensType: '렌즈유형',
+  diameter: '직경',
+  originalPrice: 100000,
+  salePrice: 80000,
+  rating: 4.5,
+  reviewCount: 123,
+  likeCount: 45,
+  hasLiked: false,
+  tags: [WdsTag.normal('태그1'), WdsTag.filled('태그2')],
+)
+
+// 가로형 레이아웃 (xs)
+WdsItemCard.xs(
+  onLiked: () => print('좋아요'),
+  thumbnailImageUrl: 'https://example.com/image.jpg',
+  productName: '상품명',
+  lensType: '렌즈유형',
+  diameter: '직경',
+  originalPrice: 100000,
+  salePrice: 80000,
+  rating: 4.5,
+  reviewCount: 123,
+  likeCount: 45,
+  hasLiked: false,
+  tags: [WdsTag.normal('태그')],
+)
+```
+
+### ItemCard - state management
+
+좋아요 상태는 `StatefulWidget`으로 관리되며, `hasLiked` 값이 변경될 때 자동으로 UI가 업데이트됩니다.
+
+``` dart
+class _WdsItemCardState extends State<WdsItemCard> {
+  @override
+  void didUpdateWidget(covariant WdsItemCard oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    
+    if (oldWidget.hasLiked != widget.hasLiked) {
+      setState(() {});
+    }
+  }
+}
+```
+
+
+## Heading
+
+헤딩(Heading)은 페이지 및 템플릿의 역할 및 기능을 나타내는 컴포넌트입니다. 텍스트와 관련 엘리먼트가 결합한 컴포넌트로 정보 계층 구조에 따라 사용을 유의합니다.
+
+### Heading - 공통
+
+- 부모 widget으로부터 size를 받아서 렌더링
+  - 가로 너비만큼 stretch되는 성격을 가짐
+- 크게 2가지 영역으로 나뉨
+  - '타이틀', '더보기' (옵션)
+    - '더보기' 버튼을 넣을 지 여부를 결정하는 요소가 필요합니다. 
+  - '더보기'는 `WdsTextButton`이 위치
+  - '타이틀'과 '더보기'는 gap: 16px
+  - '타이틀'이 Expanded 영역
+  - '타이틀'은 `Padding(padding: EdgeInsets.symmetric(vertical: 2))` 를 부모 위젯으로 갖습니다.
+- padding: `EdgeInsets.symmetric(horizontal: 16, vertical: 4)`
+
+### Heading - size
+
+- lg
+- md
+
+lg일 때는 `WdsTextButtonVariant.text`와 `WdsTextButtonSize.small` 이 쓰입니다. 그리고 타이틀은 최대 2줄까지 작성 가능해요. `Row`로 감싸게되면 `CrossAxisAlignment.start`로 상단(top)에 맞춰서 정렬합니다.
+
+md일 때는 `WdsTextButtonVariant.icon`과 `WdsTextBittonSize.small`이 쓰입니다.
+

--- a/packages/components/lib/src/button/wds_text_button.dart
+++ b/packages/components/lib/src/button/wds_text_button.dart
@@ -56,6 +56,7 @@ class WdsTextButton extends StatefulWidget {
     this.isEnabled = true,
     this.variant = WdsTextButtonVariant.text,
     this.size = WdsTextButtonSize.medium,
+    this.color = WdsColors.textNeutral,
     super.key,
   });
 
@@ -64,6 +65,7 @@ class WdsTextButton extends StatefulWidget {
   final bool isEnabled;
   final WdsTextButtonVariant variant;
   final WdsTextButtonSize size;
+  final Color color;
 
   @override
   State<WdsTextButton> createState() => _WdsTextButtonState();
@@ -116,7 +118,7 @@ class _WdsTextButtonState extends State<WdsTextButton>
   @override
   Widget build(BuildContext context) {
     final Color effectiveColor =
-        widget.isEnabled ? WdsColors.textNormal : WdsColors.textDisable;
+        widget.isEnabled ? widget.color : WdsColors.textDisable;
     final double height = _TextButtonHeightBySize.of(widget.size);
     final EdgeInsets padding = _TextButtonPaddingBySize.of(widget.size);
     final TextStyle baseTypography =

--- a/packages/components/lib/src/heading/wds_heading.dart
+++ b/packages/components/lib/src/heading/wds_heading.dart
@@ -1,0 +1,101 @@
+part of '../../wds_components.dart';
+
+enum WdsHeadingSize { lg, md }
+
+class _HeadingMaxLinesBySize {
+  const _HeadingMaxLinesBySize._();
+
+  static int of(WdsHeadingSize size) {
+    return switch (size) {
+      WdsHeadingSize.lg => 2,
+      WdsHeadingSize.md => 1,
+    };
+  }
+}
+
+class _HeadingTextButtonVariantBySize {
+  const _HeadingTextButtonVariantBySize._();
+
+  static WdsTextButtonVariant of(WdsHeadingSize size) {
+    return switch (size) {
+      WdsHeadingSize.lg => WdsTextButtonVariant.text,
+      WdsHeadingSize.md => WdsTextButtonVariant.icon,
+    };
+  }
+}
+
+/// 페이지 및 템플릿의 역할 및 기능을 나타내는 헤딩 컴포넌트
+class WdsHeading extends StatelessWidget {
+  const WdsHeading.lg({
+    required this.title,
+    this.moreText,
+    this.onMoreTap,
+    super.key,
+  }) : size = WdsHeadingSize.lg;
+
+  const WdsHeading.md({
+    required this.title,
+    this.moreText,
+    this.onMoreTap,
+    super.key,
+  }) : size = WdsHeadingSize.md;
+
+  final String title;
+
+  final WdsHeadingSize size;
+
+  final String? moreText;
+
+  final VoidCallback? onMoreTap;
+
+  @override
+  Widget build(BuildContext context) {
+    const EdgeInsets containerPadding = EdgeInsets.symmetric(
+      horizontal: 16,
+      vertical: 4,
+    );
+    const EdgeInsets titlePadding = EdgeInsets.symmetric(vertical: 2);
+    final int maxLines = _HeadingMaxLinesBySize.of(size);
+    final WdsTextButtonVariant buttonVariant =
+        _HeadingTextButtonVariantBySize.of(size);
+
+    Widget titleWidget = Padding(
+      padding: titlePadding,
+      child: Text(
+        title,
+        maxLines: maxLines,
+        overflow: TextOverflow.ellipsis,
+        style: switch (size) {
+          WdsHeadingSize.lg => WdsTypography.heading17Bold,
+          WdsHeadingSize.md => WdsTypography.heading16Bold,
+        }
+            .copyWith(color: WdsColors.textNormal),
+      ),
+    );
+
+    Widget content;
+    if (moreText != null && onMoreTap != null) {
+      content = Row(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        spacing: 16,
+        children: [
+          Expanded(child: titleWidget),
+          WdsTextButton(
+            onTap: onMoreTap,
+            variant: buttonVariant,
+            size: WdsTextButtonSize.small,
+            color: WdsColors.textAssistive,
+            child: Text(moreText!),
+          ),
+        ],
+      );
+    } else {
+      content = titleWidget;
+    }
+
+    return Padding(
+      padding: containerPadding,
+      child: content,
+    );
+  }
+}

--- a/packages/components/lib/wds_components.dart
+++ b/packages/components/lib/wds_components.dart
@@ -22,6 +22,7 @@ part 'src/checkbox/wds_checkbox.dart';
 part 'src/chip/wds_chip.dart';
 part 'src/divider/wds_divider.dart';
 part 'src/header/wds_header.dart';
+part 'src/heading/wds_heading.dart';
 part 'src/icon/wds_icon_button.dart';
 part 'src/navigation/wds_bottom_navigation.dart';
 part 'src/pagination/wds_count_pagination.dart';

--- a/packages/widgetbook/lib/main.directories.g.dart
+++ b/packages/widgetbook/lib/main.directories.g.dart
@@ -32,6 +32,8 @@ import 'package:wds_widgetbook/src/component/dot_pagination_use_case.dart'
     as _wds_widgetbook_src_component_dot_pagination_use_case;
 import 'package:wds_widgetbook/src/component/header_use_case.dart'
     as _wds_widgetbook_src_component_header_use_case;
+import 'package:wds_widgetbook/src/component/heading_use_case.dart'
+    as _wds_widgetbook_src_component_heading_use_case;
 import 'package:wds_widgetbook/src/component/icon_button_use_case.dart'
     as _wds_widgetbook_src_component_icon_button_use_case;
 import 'package:wds_widgetbook/src/component/radio_use_case.dart'
@@ -150,6 +152,14 @@ final directories = <_widgetbook.WidgetbookNode>[
           name: 'Header',
           builder: _wds_widgetbook_src_component_header_use_case
               .buildWdsHeaderUseCase,
+        ),
+      ),
+      _widgetbook.WidgetbookLeafComponent(
+        name: 'Heading',
+        useCase: _widgetbook.WidgetbookUseCase(
+          name: 'Heading',
+          builder: _wds_widgetbook_src_component_heading_use_case
+              .buildWdsHeadingUseCase,
         ),
       ),
       _widgetbook.WidgetbookLeafComponent(

--- a/packages/widgetbook/lib/src/component/heading_use_case.dart
+++ b/packages/widgetbook/lib/src/component/heading_use_case.dart
@@ -1,0 +1,118 @@
+import 'package:wds_widgetbook/src/widgetbook_components/widgetbook_components.dart';
+import 'package:widgetbook/widgetbook.dart';
+import 'package:widgetbook_annotation/widgetbook_annotation.dart' as widgetbook;
+
+@widgetbook.UseCase(
+  name: 'Heading',
+  type: Heading,
+  path: '[component]/',
+)
+Widget buildWdsHeadingUseCase(BuildContext context) {
+  return WidgetbookPageLayout(
+    title: 'Heading',
+    description:
+        '헤딩(Heading)은 페이지 및 템플릿의 역할 및 기능을 나타내는 컴포넌트입니다. 텍스트와 관련 엘리먼트가 결합한 컴포넌트로 정보 계층 구조에 따라 사용을 유의합니다.',
+    children: [
+      _buildPlaygroundSection(context),
+      _buildDemonstrationSection(context),
+    ],
+  );
+}
+
+Widget _buildPlaygroundSection(BuildContext context) {
+  final size = context.knobs.object.dropdown<WdsHeadingSize>(
+    label: 'size',
+    options: WdsHeadingSize.values,
+    initialOption: WdsHeadingSize.lg,
+    labelBuilder: (value) => value.name,
+    description: '크기를 선택할 수 있어요',
+  );
+  final title = context.knobs.string(
+    label: 'title',
+    initialValue: '타이틀은 최대 2줄까지 작성해요',
+    description: '제목 텍스트예요',
+  );
+  final enableMore = context.knobs.boolean(
+    label: 'hasMore',
+    initialValue: true,
+    description: '더보기 버튼을 표시할지 여부예요',
+  );
+  final moreText = context.knobs.string(
+    label: 'moreText',
+    initialValue: '더보기',
+    description: '더보기 버튼의 텍스트예요',
+  );
+
+  String? effectiveMoreText = enableMore ? moreText : null;
+  VoidCallback? onMoreTap = enableMore ? () => debugPrint('more tapped') : null;
+
+  return WidgetbookPlayground(
+    layout: PlaygroundLayout.stretch,
+    backgroundColor: WdsColors.coolNeutral50,
+    info: [
+      'layout: stretch',
+      'size: ${size.name}',
+      'hasMore: $enableMore',
+      if (enableMore) 'moreText: $moreText',
+    ],
+    child: switch (size) {
+      WdsHeadingSize.lg => WdsHeading.lg(
+          title: title,
+          moreText: effectiveMoreText,
+          onMoreTap: onMoreTap,
+        ),
+      WdsHeadingSize.md => WdsHeading.md(
+          title: title,
+          moreText: effectiveMoreText,
+          onMoreTap: onMoreTap,
+        ),
+    },
+  );
+}
+
+Widget _buildDemonstrationSection(BuildContext context) {
+  return WidgetbookSection(
+    title: 'Heading',
+    spacing: 32,
+    children: [
+      WidgetbookSubsection(
+        title: 'size',
+        labels: ['lg', 'md'],
+        content: Column(
+          crossAxisAlignment: CrossAxisAlignment.stretch,
+          spacing: 16,
+          children: [
+            WdsHeading.lg(
+              title: '타이틀은 최대 2줄까지 작성해요',
+              moreText: '더보기',
+              onMoreTap: () => debugPrint('more tapped'),
+            ),
+            WdsHeading.md(
+              title: '타이틀은 최대 2줄까지 작성해요',
+              moreText: '더보기',
+              onMoreTap: () => debugPrint('more tapped'),
+            ),
+          ],
+        ),
+      ),
+      WidgetbookSubsection(
+        title: 'textButton',
+        labels: const ['true', 'false'],
+        content: Column(
+          crossAxisAlignment: CrossAxisAlignment.stretch,
+          spacing: 16,
+          children: [
+            WdsHeading.lg(
+              title: '더보기 버튼이 있는 헤딩',
+              moreText: '더보기',
+              onMoreTap: () => debugPrint('more tapped'),
+            ),
+            const WdsHeading.lg(
+              title: '더보기 버튼이 없는 헤딩',
+            ),
+          ],
+        ),
+      ),
+    ],
+  );
+}

--- a/packages/widgetbook/lib/src/widgetbook_components/widgetbook_components.dart
+++ b/packages/widgetbook/lib/src/widgetbook_components/widgetbook_components.dart
@@ -44,6 +44,9 @@ class IconButton {}
 class Header {}
 
 /// 컴포넌트 path 관리를 위한 클래스
+class Heading {}
+
+/// 컴포넌트 path 관리를 위한 클래스
 class BottomNavigation {}
 
 /// 컴포넌트 path 관리를 위한 클래스


### PR DESCRIPTION
## ✅ 주요 변경 요약

### 1. **새로운 Heading 컴포넌트 구현**
* `WdsHeading` 위젯 추가
 * 크기 변형(`lg`, `md`) 지원
 * 동적 최대 라인 수 및 선택적 "더보기" 버튼 기능
 * 텍스트 표시 및 확장을 위한 유연한 레이아웃 옵션
* 포괄적인 문서화
 * `docs/wds_component_guide.md`에 사용법, 속성, 레이아웃 가이드라인 포함한 상세 문서 추가
* 디자인 시스템 등록
 * 메인 entry 파일에 새 컴포넌트 등록 및 `Heading`용 경로 관리 클래스 추가

---

### 2. **Widgetbook 통합 및 데모**
* 전용 Heading 유스케이스 추가
 * 상호작용 테스트 및 문서화를 위한 플레이그라운드 및 시연 섹션 포함
* Widgetbook 디렉토리 등록
 * 컴포넌트 탐색기에서 가시성을 위해 Widgetbook의 디렉토리 구조에 `Heading` 유스케이스 등록

---

### 3. **버튼 커스터마이징 개선**
* `WdsTextButton` 유연성 향상
 * 커스텀 `color` 속성 수락으로 더 유연한 스타일링 지원
 * `Heading` 컴포넌트와의 더 나은 통합 및 일관성 제공

---

## 📋 **주요 변경 포인트**
* **텍스트 계층 구조를 위한 전문화된 Heading 컴포넌트 추가**
* **동적 텍스트 확장 기능으로 콘텐츠 표시 유연성 향상**
* **커스텀 색상 지원으로 버튼 컴포넌트 재사용성 개선**
* **상호작용 가능한 Widgetbook 데모로 컴포넌트 탐색 및 테스트 지원**

---

## ☑️ **마이그레이션/배포 체크리스트**
* `WdsHeading` 컴포넌트의 lg 및 md 크기 변형이 올바른 타이포그래피로 렌더링되는지 확인
* 동적 최대 라인 수 기능이 다양한 텍스트 길이에서 정상 작동하는지 테스트
* "더보기" 버튼이 텍스트 오버플로우 시 적절히 표시되고 상호작용하는지 검증
* `WdsTextButton`의 새로운 커스텀 색상 속성이 다양한 색상 값에서 올바르게 적용되는지 확인
* Widgetbook에서 Heading 플레이그라운드가 모든 변형과 옵션을 정상적으로 시연하는지 테스트
* Heading 컴포넌트가 `wds_components.dart`에서 정상적으로 export되고 import 가능한지 검증
* 문서화된 사용 예제가 실제 컴포넌트 구현과 정확히 일치하는지 확인
* Heading과 TextButton의 통합이 시각적으로 일관되고 조화롭게 표시되는지 테스트
* 다양한 화면 크기에서 Heading 컴포넌트가 적절히 반응하는지 검증
* 접근성 기준을 충족하도록 Heading 컴포넌트가 적절한 시맨틱 구조를 제공하는지 확인