### PR TITLE
Fix: LineTabs > Count 추가

### DIFF
--- a/docs/wds_component_guide.md
+++ b/docs/wds_component_guide.md
@@ -874,10 +874,10 @@ onTap | `ValueChanged<int>?` | 탭 선택 시 호출되는 콜백
 --- | --- | --- | ---
 label.typography | 선택됨 | `WdsTypography.body15ReadingBold` |
 label.color | 선택됨 | `WdsColors.textNormal` |
-label.padding | 선택됨 | `EdgeInsets.fromLTRB(16, 11, 16, 9)` | underline 2px 고려
+label.padding | 선택됨 | `EdgeInsets.fromLTRB(0, 11, 0, 9)` | underline 2px 고려
 label.typography | 선택 안됨 | `WdsTypography.body15ReadingMedium` |
 label.color | 선택 안됨 | `WdsColors.textNeutral` |
-label.padding | 선택 안됨 | `EdgeInsets.fromLTRB(16, 11, 16, 10)` |
+label.padding | 선택 안됨 | `EdgeInsets.fromLTRB(0, 11, 0, 10)` |
 underline | 선택됨 | 높이 2px, 너비 탭 full, color `WdsColors.black` |
 underline | 선택 안됨 | 1px solid `WdsColors.borderAlternative` |
 탭 개수 | - | 2개 또는 3개 |

--- a/packages/components/example/winc_demo/lib/main.dart
+++ b/packages/components/example/winc_demo/lib/main.dart
@@ -15,12 +15,12 @@ const double $maxMobileCrossAxisCountForTwo = 375;
 
 extension on String {
   WdsTag toTag() => switch (this) {
-    'NEW' => const WdsTag.$new(),
-    'SALE' => const WdsTag.$sale(),
-    'BEST' => const WdsTag.$best(),
-    '쿠폰사용가능' => const WdsTag.$coupon(),
-    _ => WdsTag.normal(label: this),
-  };
+        'NEW' => const WdsTag.$new(),
+        'SALE' => const WdsTag.$sale(),
+        'BEST' => const WdsTag.$best(),
+        '쿠폰사용가능' => const WdsTag.$coupon(),
+        _ => WdsTag.normal(label: this),
+      };
 }
 
 void main() async {
@@ -99,7 +99,6 @@ class _WDSDemoState extends State<WDSDemo> {
           const Center(child: Text('마이윙크')),
         ],
       ),
-
       bottomNavigationBar: WdsBottomNavigation(
         items: [
           const WdsBottomNavigationItem(
@@ -139,7 +138,7 @@ class HomeView extends StatefulWidget {
 
 class _HomeViewState extends State<HomeView>
     with SingleTickerProviderStateMixin {
-  final WdsTextTabsController tabController = WdsTextTabsController(length: 6);
+  final WdsTabsController tabController = WdsTabsController(length: 6);
 
   @override
   void dispose() {
@@ -167,7 +166,6 @@ class _HomeViewState extends State<HomeView>
           ),
         ],
       ),
-
       body: Column(
         children: [
           ColoredBox(
@@ -339,7 +337,7 @@ class _HomeTabState extends State<HomeTab> {
                       bottom: 16,
                       child: AnimatedBuilder(
                         animation: pageController,
-                        builder: (_, _) => WdsCountPagination(
+                        builder: (_, __) => WdsCountPagination(
                           currentPage: (pageController.page?.toInt() ?? 0) + 1,
                           totalPage: HomeTab.bannerImageUrls.length,
                         ),
@@ -375,7 +373,7 @@ class _HomeTabState extends State<HomeTab> {
                       url,
                       width: 62,
                       height: 62,
-                      errorBuilder: (_, _, _) => const _DefaultQuickItem(),
+                      errorBuilder: (_, __, ___) => const _DefaultQuickItem(),
                     );
                   } else {
                     icon = Image.network(url, width: 62, height: 62);
@@ -460,19 +458,16 @@ class _HomeTabState extends State<HomeTab> {
           builder: (context, constraints) {
             final width = constraints.crossAxisExtent;
 
-            final crossAxisCount = width <= $maxMobileCrossAxisCountForTwo
-                ? 2
-                : 3;
+            final crossAxisCount =
+                width <= $maxMobileCrossAxisCountForTwo ? 2 : 3;
 
-            final scaleFactor =
-                width /
+            final scaleFactor = width /
                 (WdsItemCardSize.xl.thumbnailSize.size.width * crossAxisCount);
 
             final scaledThumnailHeight =
                 WdsItemCardSize.xl.thumbnailSize.size.height * scaleFactor;
 
-            final otherElementHeight =
-                WdsItemCardSize.xl.cardHeight -
+            final otherElementHeight = WdsItemCardSize.xl.cardHeight -
                 WdsItemCardSize.xl.thumbnailSize.size.height;
 
             final totalCardHeight = scaledThumnailHeight + otherElementHeight;
@@ -583,11 +578,10 @@ class _HomeTabState extends State<HomeTab> {
                         width: constraints.crossAxisExtent,
                         height: 200 * scaleFactor,
                         fit: BoxFit.cover,
-                        cacheWidth: (constraints.crossAxisExtent * ratio)
-                            .toInt(),
+                        cacheWidth:
+                            (constraints.crossAxisExtent * ratio).toInt(),
                         alignment: const Alignment(0, -0.25),
                       ),
-
                       Positioned(
                         left: 16,
                         bottom: 16,
@@ -637,15 +631,13 @@ class _HomeTabState extends State<HomeTab> {
             builder: (context, constraints) {
               final width = constraints.crossAxisExtent;
 
-              final crossAxisCount = width <= $maxMobileCrossAxisCountForTwo
-                  ? 2
-                  : 3;
+              final crossAxisCount =
+                  width <= $maxMobileCrossAxisCountForTwo ? 2 : 3;
 
               return SliverList.separated(
-                itemCount: $dummyProducts
-                    .take(crossAxisCount == 2 ? 3 : 5)
-                    .length,
-                separatorBuilder: (_, _) => const SizedBox(height: 10),
+                itemCount:
+                    $dummyProducts.take(crossAxisCount == 2 ? 3 : 5).length,
+                separatorBuilder: (_, __) => const SizedBox(height: 10),
                 itemBuilder: (context, index) {
                   final product = $dummyProducts[index];
 

--- a/packages/components/lib/src/tab/wds_tab.dart
+++ b/packages/components/lib/src/tab/wds_tab.dart
@@ -323,6 +323,29 @@ class _WdsTextTabsState extends State<WdsTextTabs> {
   }
 }
 
+/// WdsLineTabs에서 사용할 개별 탭 데이터 클래스
+class WdsLineTab {
+  const WdsLineTab({
+    required this.title,
+    this.count,
+  });
+
+  /// 탭에 표시할 제목
+  final String title;
+
+  /// 탭에 표시할 카운트 (선택사항)
+  final int? count;
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) return true;
+    return other is WdsLineTab && other.title == title && other.count == count;
+  }
+
+  @override
+  int get hashCode => Object.hash(title, count);
+}
+
 /// 균등 너비 + 선택 탭에 언더라인이 표시되는 탭
 class WdsLineTabs extends StatefulWidget {
   const WdsLineTabs({
@@ -332,7 +355,8 @@ class WdsLineTabs extends StatefulWidget {
     super.key,
   }) : assert(tabs.length == 2 || tabs.length == 3);
 
-  final List<String> tabs;
+  /// 표시할 탭들의 리스트
+  final List<WdsLineTab> tabs;
 
   /// 탭 컨트롤러 (선택사항)
   final WdsTextTabsController? controller;
@@ -387,6 +411,7 @@ class _WdsLineTabsState extends State<WdsLineTabs> {
 
   Expanded _buildItem(int index) {
     final isSelected = index == _controller.index;
+    final tab = widget.tabs[index];
 
     final labelStyle = isSelected
         ? WdsTypography.body15ReadingBold.copyWith(
@@ -395,6 +420,11 @@ class _WdsLineTabsState extends State<WdsLineTabs> {
         : WdsTypography.body15ReadingMedium.copyWith(
             color: WdsColors.textNeutral,
           );
+
+    /// 최종 표시할 텍스트
+    final displayText = tab.count != null
+        ? '${tab.title}(${tab.count!.toFormat()})'
+        : tab.title;
 
     return Expanded(
       child: GestureDetector(
@@ -416,8 +446,8 @@ class _WdsLineTabsState extends State<WdsLineTabs> {
             ),
             Align(
               child: Padding(
-                padding: const EdgeInsets.fromLTRB(16, 11, 16, 10),
-                child: Text(widget.tabs[index], style: labelStyle),
+                padding: const EdgeInsets.fromLTRB(0, 11, 0, 10),
+                child: Text(displayText, style: labelStyle),
               ),
             ),
             if (isSelected)

--- a/packages/components/lib/src/tab/wds_tab.dart
+++ b/packages/components/lib/src/tab/wds_tab.dart
@@ -353,7 +353,7 @@ class WdsLineTabs extends StatefulWidget {
     this.controller,
     this.onTap,
     super.key,
-  }) : assert(tabs.length == 2 || tabs.length == 3);
+  });
 
   /// 표시할 탭들의 리스트
   final List<WdsLineTab> tabs;

--- a/packages/components/lib/src/tab/wds_tab.dart
+++ b/packages/components/lib/src/tab/wds_tab.dart
@@ -9,9 +9,9 @@ enum WdsTextTabVariant {
   featured,
 }
 
-/// WdsTextTabs의 컨트롤러
-class WdsTextTabsController extends ChangeNotifier {
-  WdsTextTabsController({
+/// WdsTextTabs & WdsLineTabs의 컨트롤러
+class WdsTabsController extends ChangeNotifier {
+  WdsTabsController({
     required this.length,
     this.initialIndex = 0,
   })  : assert(length > 0),
@@ -243,7 +243,7 @@ class WdsTextTabs extends StatefulWidget {
   final List<WdsTextTab> tabs;
 
   /// 탭 컨트롤러 (선택사항)
-  final WdsTextTabsController? controller;
+  final WdsTabsController? controller;
 
   /// 탭 선택 시 호출되는 콜백
   final ValueChanged<int>? onTap;
@@ -253,13 +253,13 @@ class WdsTextTabs extends StatefulWidget {
 }
 
 class _WdsTextTabsState extends State<WdsTextTabs> {
-  late WdsTextTabsController _controller;
+  late WdsTabsController _controller;
 
   @override
   void initState() {
     super.initState();
     _controller = widget.controller ??
-        WdsTextTabsController(
+        WdsTabsController(
           length: widget.tabs.length,
         );
   }
@@ -269,7 +269,7 @@ class _WdsTextTabsState extends State<WdsTextTabs> {
     super.didUpdateWidget(oldWidget);
     if (widget.controller != oldWidget.controller) {
       _controller = widget.controller ??
-          WdsTextTabsController(
+          WdsTabsController(
             length: widget.tabs.length,
           );
     }
@@ -359,7 +359,7 @@ class WdsLineTabs extends StatefulWidget {
   final List<WdsLineTab> tabs;
 
   /// 탭 컨트롤러 (선택사항)
-  final WdsTextTabsController? controller;
+  final WdsTabsController? controller;
 
   /// 탭 선택 시 호출되는 콜백
   final ValueChanged<int>? onTap;
@@ -369,13 +369,13 @@ class WdsLineTabs extends StatefulWidget {
 }
 
 class _WdsLineTabsState extends State<WdsLineTabs> {
-  late WdsTextTabsController _controller;
+  late WdsTabsController _controller;
 
   @override
   void initState() {
     super.initState();
     _controller = widget.controller ??
-        WdsTextTabsController(
+        WdsTabsController(
           length: widget.tabs.length,
         );
   }
@@ -385,7 +385,7 @@ class _WdsLineTabsState extends State<WdsLineTabs> {
     super.didUpdateWidget(oldWidget);
     if (widget.controller != oldWidget.controller) {
       _controller = widget.controller ??
-          WdsTextTabsController(
+          WdsTabsController(
             length: widget.tabs.length,
           );
     }

--- a/packages/widgetbook/lib/src/component/tab_use_case.dart
+++ b/packages/widgetbook/lib/src/component/tab_use_case.dart
@@ -70,8 +70,8 @@ Widget _buildLineTabsDemonstrationSection(BuildContext context) {
     title: 'LineTabs',
     children: [
       WidgetbookSubsection(
-        title: 'variant',
-        labels: const ['length == 2', 'length == 3'],
+        title: 'columns',
+        labels: const ['2', '3', '4'],
         content: Column(
           spacing: 24,
           children: [
@@ -86,8 +86,36 @@ Widget _buildLineTabsDemonstrationSection(BuildContext context) {
               tabs: const [
                 WdsLineTab(title: '텍스트'),
                 WdsLineTab(title: '텍스트'),
+                WdsLineTab(title: '텍스트'),
               ],
-              controller: WdsTabsController(length: 2, initialIndex: 1),
+              controller: WdsTabsController(length: 3, initialIndex: 1),
+            ),
+            WdsLineTabs(
+              tabs: const [
+                WdsLineTab(title: '텍스트'),
+                WdsLineTab(title: '텍스트'),
+                WdsLineTab(title: '텍스트'),
+                WdsLineTab(title: '텍스트'),
+              ],
+              controller: WdsTabsController(length: 4, initialIndex: 1),
+            ),
+          ],
+        ),
+      ),
+      const SizedBox(height: 24),
+      WidgetbookSubsection(
+        title: 'count',
+        labels: const ['true', 'false'],
+        content: Column(
+          spacing: 24,
+          children: [
+            WdsLineTabs(
+              tabs: const [
+                WdsLineTab(title: '텍스트', count: 10000),
+                WdsLineTab(title: '텍스트'),
+                WdsLineTab(title: '텍스트'),
+              ],
+              controller: WdsTabsController(length: 3, initialIndex: 1),
             ),
             WdsLineTabs(
               tabs: const [

--- a/packages/widgetbook/lib/src/component/tab_use_case.dart
+++ b/packages/widgetbook/lib/src/component/tab_use_case.dart
@@ -76,15 +76,25 @@ Widget _buildLineTabsDemonstrationSection(BuildContext context) {
           spacing: 24,
           children: [
             WdsLineTabs(
-              tabs: const ['텍스트', '텍스트'],
+              tabs: const [
+                WdsLineTab(title: '텍스트'),
+                WdsLineTab(title: '텍스트'),
+              ],
               controller: WdsTextTabsController(length: 2),
             ),
             WdsLineTabs(
-              tabs: const ['텍스트', '텍스트'],
+              tabs: const [
+                WdsLineTab(title: '텍스트'),
+                WdsLineTab(title: '텍스트'),
+              ],
               controller: WdsTextTabsController(length: 2, initialIndex: 1),
             ),
             WdsLineTabs(
-              tabs: const ['텍스트', '텍스트', '텍스트'],
+              tabs: const [
+                WdsLineTab(title: '텍스트'),
+                WdsLineTab(title: '텍스트'),
+                WdsLineTab(title: '텍스트'),
+              ],
               controller: WdsTextTabsController(length: 3, initialIndex: 1),
             ),
           ],
@@ -179,7 +189,7 @@ class _LineTabsPlaygroundState extends State<_LineTabsPlayground> {
   Widget build(BuildContext context) {
     final int count = context.knobs.object.dropdown<int>(
       label: '두번째 Playground: LineTabs',
-      description: '탭의 개수를 조절할 수 있어요.',
+      description: '탭의 개수를 조절할 수 있어요.\n\u2022 count: 1번째',
       options: const [2, 3],
       initialOption: 2,
     );
@@ -188,8 +198,16 @@ class _LineTabsPlaygroundState extends State<_LineTabsPlayground> {
       _controller = WdsTextTabsController(length: count);
     }
 
-    final List<String> tabs =
-        count == 2 ? const ['첫번째', '두번째'] : const ['첫번째', '두번째', '세번째'];
+    final List<WdsLineTab> tabs = count == 2
+        ? [
+            const WdsLineTab(title: '전체', count: 1234),
+            const WdsLineTab(title: '진행중'),
+          ]
+        : [
+            const WdsLineTab(title: '전체', count: 10000),
+            const WdsLineTab(title: '진행중'),
+            const WdsLineTab(title: '완료'),
+          ];
 
     return WidgetbookPlayground(
       info: [

--- a/packages/widgetbook/lib/src/component/tab_use_case.dart
+++ b/packages/widgetbook/lib/src/component/tab_use_case.dart
@@ -80,14 +80,14 @@ Widget _buildLineTabsDemonstrationSection(BuildContext context) {
                 WdsLineTab(title: '텍스트'),
                 WdsLineTab(title: '텍스트'),
               ],
-              controller: WdsTextTabsController(length: 2),
+              controller: WdsTabsController(length: 2),
             ),
             WdsLineTabs(
               tabs: const [
                 WdsLineTab(title: '텍스트'),
                 WdsLineTab(title: '텍스트'),
               ],
-              controller: WdsTextTabsController(length: 2, initialIndex: 1),
+              controller: WdsTabsController(length: 2, initialIndex: 1),
             ),
             WdsLineTabs(
               tabs: const [
@@ -95,7 +95,7 @@ Widget _buildLineTabsDemonstrationSection(BuildContext context) {
                 WdsLineTab(title: '텍스트'),
                 WdsLineTab(title: '텍스트'),
               ],
-              controller: WdsTextTabsController(length: 3, initialIndex: 1),
+              controller: WdsTabsController(length: 3, initialIndex: 1),
             ),
           ],
         ),
@@ -112,12 +112,12 @@ class _TextTabsPlayground extends StatefulWidget {
 }
 
 class _TextTabsPlaygroundState extends State<_TextTabsPlayground> {
-  late WdsTextTabsController _controller;
+  late WdsTabsController _controller;
 
   @override
   void initState() {
     super.initState();
-    _controller = WdsTextTabsController(length: 6, initialIndex: 1);
+    _controller = WdsTabsController(length: 6, initialIndex: 1);
   }
 
   @override
@@ -132,7 +132,7 @@ class _TextTabsPlaygroundState extends State<_TextTabsPlayground> {
     );
 
     if (_controller.length != count) {
-      _controller = WdsTextTabsController(length: count, initialIndex: 1);
+      _controller = WdsTabsController(length: count, initialIndex: 1);
     }
 
     final List<String> tabs = List.generate(count, (i) => '추천 ${i + 1}');
@@ -177,12 +177,12 @@ class _LineTabsPlayground extends StatefulWidget {
 }
 
 class _LineTabsPlaygroundState extends State<_LineTabsPlayground> {
-  late WdsTextTabsController _controller;
+  late WdsTabsController _controller;
 
   @override
   void initState() {
     super.initState();
-    _controller = WdsTextTabsController(length: 2);
+    _controller = WdsTabsController(length: 2);
   }
 
   @override
@@ -195,7 +195,7 @@ class _LineTabsPlaygroundState extends State<_LineTabsPlayground> {
     );
 
     if (_controller.length != count) {
-      _controller = WdsTextTabsController(length: count);
+      _controller = WdsTabsController(length: count);
     }
 
     final List<WdsLineTab> tabs = count == 2


### PR DESCRIPTION
## ✅ 주요 변경 요약

### 1. `LineTabs` 컴포넌트 데이터 모델 개선
- `WdsLineTab` 데이터 클래스를 새로 도입해 탭의 제목(`title`) 과 선택적 카운트(`count`) 를 함께 관리
- 기존 문자열 기반 탭 정의를 `WdsLineTab` 객체 리스트 기반으로 교체
- `WdsLineTabs` 위젯과 관련 사용처 업데이트

### 2. UI 및 표시 개선
- 탭 라벨 옆에 카운트 값(포맷팅된 숫자)을 표시하는 로직 추가
- 선택/비선택 상태 모두에서 탭 라벨의 패딩 값 조정으로 언더라인과 시각적 정렬 개선
- LineTab label 양 여백 16px 삭제

### 3. 문서 및 Playground 업데이트
- 컴포넌트 가이드에 `WdsLineTab` 기반 사용 예시 및 카운트 표시 기능 추가
- Widgetbook Playground에 카운트 포함 탭 사례 추가해 상호작용 테스트 및 시연 가능

## 📋 주요 변경 포인트
- 문자열 대신 `WdsLineTab` 데이터 클래스로 탭을 정의 → 확장성과 명확성 향상
- 탭 옆 카운트 표시 → 상품 개수 등 맥락 전달에 유용
- 탭 패딩 조정 → 언더라인과 라벨 정렬감 개선
- 문서/Widgetbook 예제 업데이트로 디자인-개발 간 일관된 가이드 제공

## ☑️ 마이그레이션/배포 체크리스트
- 기존 문자열 기반 `WdsLineTabs` 사용처가 모두 `WdsLineTab` 객체 기반으로 정상 동작하는지 확인
- 카운트가 없는 경우 UI가 올바르게 표시되는지 검증
- 카운트가 매우 큰 숫자일 때 포맷팅이 정상적으로 적용되는지 확인
- 선택/비선택 상태에서 탭 라벨과 언더라인 정렬이 의도대로 동작하는지 테스트
- Widgetbook에서 카운트 포함 탭 Playground가 정상 동작하고 문서화와 일치하는지 검증