### PR TITLE
Feature: Option 추가

### DIFF
--- a/docs/wds_component_guide.md
+++ b/docs/wds_component_guide.md
@@ -2544,3 +2544,99 @@ md일 때는 `WdsTextButtonVariant.icon`과 `WdsTextBittonSize.small`이 쓰입�
 **medium**
 - spacing: `WdsSpacing.md5`
 - backgroundColor: 18
+
+
+## Option
+
+Select 영역에서 원하는 옵션을 선택할 수 있도록 돕습니다.
+
+**공통**:
+Select가 열리면(`isExpanded: true`) 여러 OptionItem들을 감싸고 있는 Option이 보이게 됩니다. 
+이 때, Option은 left, right, 그리고 bottom에 `WdsColors.primary`로 칠해진 stroke를 가지며,
+배경 색상은 `WdsColors.backgroundNormal`을 가집니다. stroke의 두께는 1px이고 bottomLeft, bottomRight에는 borderRadius 를 `Radius.circular(WdsRadius.sm)`로 둡니다.
+
+그리고 각 OptionItem은 top, bottom에 stroke를 `WdsColors.borderAlternative` 색상으로 1px 씩 가집니다. 다만, 가장 마지막 OptionItem은 Option처럼 bottomLeft, bottomRight가 `Radius.circular(WdsRadius.sm)`로 그려집니다. 가장 바깥의 stroke가 (Option의 border) 안의 영역의 (OptionItem의 border) 보다 우선순위가 높습니다.
+
+Option은 variant와 isSoldOut 로 조합될 수 있습니다.
+
+### Option - variant
+
+- power
+- product
+
+**power**
+- 높이: top/bottom border 1px 제외하고 고정 높이 47px
+- padding: left/right 각각 16px
+- 정렬: `CrossAxisAlignment.center`
+
+**power 구조**
+- label (필수)
+  - 너비: 고정 40px
+  - 높이: 부모 Widget 따라 20px
+  - 색상: `WdsTypography.body14NormalRegular.copyWith(color: WdsColors.textNormal)`
+  - isSoldOut true일 때: `WdsColors.textDisable`
+- tags (선택사항)
+  - 최대 2개
+  - 간격: label과 8px, tags 간 2px
+  - Widget: `WdsTag`만 허용
+  - 높이: 20px (부모 Widget 기준 위/아래 각 1px 간격)
+  - 구조: Expanded
+  - isSoldOut true일 때: 맨 앞에 `WdsTag.$soldOut` 추가
+- trailing (선택사항)
+  - 조건: `isSoldOut`이 true일 때만 표시
+  - Widget: `WdsChip.pill(variant: .outline, size: .xs)`
+  - 간격: label + tags와 10px
+  - 높이: `WdsChip` 속성 존중 (고정 20px 아님)
+
+**power 위젯 트리**
+```
+Option
+├ OptionItem (gap: 10px)
+⎮  ├ Row (gap: 8px, fixed height: 20px)
+⎮  ⎮  ├ label (required)
+⎮  ⎮  ├ tags (optional, expanded)
+⎮  ├ trailing (optional)
+```
+
+**product**
+- 높이: top/bottom border 1px 제외하고 고정 높이 63px
+- padding: left/right 16px, top/bottom 8px
+- 구성 요소: index, thumbnail, title, description, trailing
+
+**product 구조**
+- index (필수)
+  - 크기: 고정 18px × 20px
+- thumbnail (필수)
+  - 크기: 고정 크기
+- title (필수)
+  - 스타일: `WdsTypography.body14NormalMedium`
+  - 색상: `WdsColors.textNormal`
+  - 제한: maxLine 1, ellipsis
+  - 구조: Expanded
+- description (필수)
+  - 스타일: `WdsTypography.body13NormalRegular`
+  - 색상: `WdsColors.textAlternative`
+  - 제한: maxLine 1, ellipsis
+- trailing (선택사항)
+
+**product 위젯 트리**
+```
+Option
+├ OptionItem (gap: 10px)
+⎮  ├ Row (gap: 4px, fixedSize: 86px * 64px, crossAxisAlignment: .start)
+⎮  ⎮  ├ index (required, fixed size: 18 * 20 px)
+⎮  ⎮  ├ thumbnail (required, fixed size)
+⎮  ├ Column(gap: 4px, crossAxisAlignment: .stretch)
+⎮  ⎮  ├ Row (gap: 4px) 
+⎮  ⎮  ⎮  ├ title (required, WdsTypography.body14NormalMedium, WdsColors.textNormal, maxLine: 1, .ellipsis, expanded)
+⎮  ⎮  ⎮  ├ trailing (optional)
+⎮  ⎮  ├ description (required, WdsTypography.body13NormalRegular, WdsColors.textAlternative, maxLine: 1, .ellipsis)
+```
+
+### Option - 공통 규칙
+
+- 부모 위젯이 Row/Column이고 자식 위젯이 1개인 경우: Row/Column 없이 바로 자식 return
+- 고정 높이: OptionItem 개수에 비례
+- 최대 높이: power 6개, product 5개
+- 스크롤: 최대 높이 초과 시 고정 높이 내 스크롤 영역 생성
+- 유동 높이: 최대 높이 미만 시 wrap 높이만큼 고정 높이 생성

--- a/packages/components/lib/src/option/wds_option.dart
+++ b/packages/components/lib/src/option/wds_option.dart
@@ -1,0 +1,445 @@
+part of '../../wds_components.dart';
+
+enum WdsOptionVariant {
+  power(
+    maxHeight: 289,
+    scrollThreshold: 6,
+    padding: EdgeInsets.symmetric(horizontal: 16),
+    itemHeight: 47,
+  ),
+  product(
+    maxHeight: 401,
+    scrollThreshold: 5,
+    padding: EdgeInsets.fromLTRB(16, 8, 16, 8),
+    itemHeight: 63,
+  );
+
+  const WdsOptionVariant({
+    required this.maxHeight,
+    required this.scrollThreshold,
+    required this.padding,
+    required this.itemHeight,
+  });
+
+  /// 고정된 최대 높이 (모든 border 포함)
+  final double maxHeight;
+
+  /// 스크롤이 필요한 최소 아이템 개수
+  final int scrollThreshold;
+
+  final EdgeInsets padding;
+
+  final double itemHeight;
+}
+
+/// Select 영역에서 원하는 옵션을 선택할 수 있도록 돕는 컴포넌트
+///
+/// Select가 열리면(`isExpanded: true`) 여러 OptionItem들을 감싸고 있는 Option이 보이게 됩니다.
+/// 이 때, Option은 left, right, 그리고 bottom에 `WdsColors.primary`로 칠해진 stroke를 가지며,
+/// 배경 색상은 `WdsColors.backgroundNormal`을 가집니다.
+class WdsOption extends StatelessWidget {
+  const WdsOption.power({
+    required this.items,
+    super.key,
+  }) : variant = WdsOptionVariant.power;
+
+  const WdsOption.product({
+    required this.items,
+    super.key,
+  }) : variant = WdsOptionVariant.product;
+
+  /// Option의 variant (power 또는 product)
+  final WdsOptionVariant variant;
+
+  /// OptionItem들의 리스트
+  final List<WdsOptionItem> items;
+
+  static const BoxDecoration _decoration = BoxDecoration(
+    color: WdsColors.backgroundNormal,
+    border: Border(
+      left: BorderSide(color: WdsColors.primary),
+      right: BorderSide(color: WdsColors.primary),
+      bottom: BorderSide(color: WdsColors.primary),
+    ),
+    borderRadius: BorderRadius.only(
+      bottomLeft: Radius.circular(WdsRadius.sm),
+      bottomRight: Radius.circular(WdsRadius.sm),
+    ),
+  );
+
+  @override
+  Widget build(BuildContext context) {
+    return RepaintBoundary(
+      child: DecoratedBox(
+        decoration: _decoration,
+        child: Padding(
+          padding: const EdgeInsets.symmetric(horizontal: 1),
+          child: _buildContent(),
+        ),
+      ),
+    );
+  }
+
+  Widget _buildContent() {
+    if (items.isEmpty) {
+      return const SizedBox.shrink();
+    }
+
+    if (items.length == 1) {
+      return WdsOptionItemWrapper(
+        item: items.first,
+        variant: variant,
+        isLast: true,
+      );
+    }
+
+    /// 스크롤이 필요한지 확인
+    final shouldScroll = _shouldShowScroll();
+
+    /// 스크롤이 필요한 경우 고정 높이로 스크롤 영역 생성
+    if (shouldScroll) {
+      return SizedBox(
+        height: variant.maxHeight,
+        child: SingleChildScrollView(
+          child: Column(
+            children: _buildItems(),
+          ),
+        ),
+      );
+    }
+
+    /// 스크롤이 필요 없는 경우 wrap 높이로 생성
+    return Column(
+      mainAxisSize: MainAxisSize.min,
+      children: _buildItems(),
+    );
+  }
+
+  /// 스크롤이 필요한지 판단하는 메서드
+  bool _shouldShowScroll() {
+    return items.length > variant.scrollThreshold;
+  }
+
+  List<Widget> _buildItems() {
+    final List<Widget> widgets = [];
+
+    for (int i = 0; i < items.length; i++) {
+      final item = items[i];
+      final isLast = i == items.length - 1;
+
+      widgets.add(
+        WdsOptionItemWrapper(
+          item: item,
+          variant: variant,
+          isLast: isLast,
+        ),
+      );
+    }
+
+    return widgets;
+  }
+}
+
+/// OptionItem을 감싸는 래퍼 위젯
+/// 성능 최적화를 위해 RepaintBoundary 적용
+class WdsOptionItemWrapper extends StatelessWidget {
+  const WdsOptionItemWrapper({
+    required this.item,
+    required this.variant,
+    required this.isLast,
+    super.key,
+  });
+
+  final WdsOptionItem item;
+  final WdsOptionVariant variant;
+  final bool isLast;
+
+  static const BoxDecoration _topBorderDecoration = BoxDecoration(
+    border: Border(
+      top: BorderSide(color: WdsColors.borderAlternative),
+    ),
+  );
+
+  static const BoxDecoration _topBottomBorderDecoration = BoxDecoration(
+    border: Border(
+      top: BorderSide(color: WdsColors.borderAlternative),
+    ),
+    borderRadius: BorderRadius.only(
+      bottomLeft: Radius.circular(WdsRadius.sm),
+      bottomRight: Radius.circular(WdsRadius.sm),
+    ),
+  );
+
+  @override
+  Widget build(BuildContext context) {
+    final decoration =
+        isLast ? _topBottomBorderDecoration : _topBorderDecoration;
+
+    return RepaintBoundary(
+      child: DecoratedBox(
+        decoration: decoration,
+        child: Padding(
+          padding: variant.padding,
+          child: SizedBox(
+            height: variant.itemHeight,
+            child: item.build(context, variant),
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+/// Option 내부의 개별 아이템을 나타내는 추상 클래스
+abstract class WdsOptionItem {
+  const WdsOptionItem();
+
+  /// OptionItem을 렌더링하는 메서드
+  Widget build(BuildContext context, WdsOptionVariant variant);
+}
+
+/// Power variant용 OptionItem
+class WdsPowerOptionItem extends WdsOptionItem {
+  const WdsPowerOptionItem({
+    required this.label,
+    this.tags = const [],
+    this.isSoldOut = false,
+    this.hasRegistered = false,
+    this.onTap,
+  });
+
+  /// 필수 라벨
+  final String label;
+
+  /// 선택적 태그들 (최대 2개)
+  final List<WdsTag> tags;
+
+  /// 품절 상태
+  final bool isSoldOut;
+
+  /// 입고알림 등록 여부
+  final bool hasRegistered;
+
+  /// 탭 콜백
+  final VoidCallback? onTap;
+
+  static const TextStyle _labelStyle = WdsTypography.body14NormalRegular;
+
+  static const SizedBox _tagSpacing = SizedBox(width: 8);
+  static const SizedBox _trailingSpacing = SizedBox(width: 10);
+
+  @override
+  Widget build(BuildContext context, WdsOptionVariant variant) {
+    assert(
+      variant == WdsOptionVariant.power,
+      'PowerOptionItem은 power variant에서만 사용 가능합니다',
+    );
+
+    return GestureDetector(
+      onTap: onTap,
+      child: Row(
+        children: [
+          // Label (고정 너비 40px)
+          SizedBox(
+            width: 40,
+            height: 20,
+            child: Text(
+              label,
+              style: _labelStyle.copyWith(
+                color: isSoldOut ? WdsColors.textDisable : WdsColors.textNormal,
+              ),
+              textAlign: TextAlign.start,
+            ),
+          ),
+
+          // Tags 영역 (Expanded)
+          if (tags.isNotEmpty || isSoldOut) ...[
+            _tagSpacing,
+            Expanded(
+              child: Row(
+                mainAxisSize: MainAxisSize.min,
+                spacing: 2,
+                children: [
+                  /// 품절 태그가 있으면 맨 앞에 추가
+                  if (isSoldOut) ...[
+                    const WdsTag.$soldOut(),
+                  ],
+
+                  /// 기존 태그들
+                  if (tags.isNotEmpty) ...[
+                    ...tags
+                        .take(2)
+                        .expand((tag) => [tag])
+                        .take(tags.length * 2 - 1), // 마지막 spacing 제거
+                  ],
+                ],
+              ),
+            ),
+          ],
+
+          /// Trailing (품절 상태일 때만 표시)
+          if (isSoldOut) ...[
+            _trailingSpacing,
+            if (hasRegistered)
+              WdsChip.pill(
+                onTap: onTap,
+                label: '알림받는중',
+                value: 'r',
+                groupValues: {},
+                size: WdsChipSize.xsmall,
+                variant: WdsChipVariant.solid,
+              )
+            else
+              WdsChip.pill(
+                onTap: onTap,
+                label: '입고알림',
+                value: 'ㄴ',
+                groupValues: {},
+                size: WdsChipSize.xsmall,
+              ),
+          ],
+        ],
+      ),
+    );
+  }
+}
+
+/// Product variant용 OptionItem
+class WdsProductOptionItem extends WdsOptionItem {
+  const WdsProductOptionItem({
+    required this.index,
+    required this.thumbnail,
+    required this.title,
+    required this.description,
+    this.trailing,
+    this.onTap,
+    this.isSoldOut = false,
+  });
+
+  /// 필수 인덱스
+  final String index;
+
+  /// 필수 썸네일
+  final Widget thumbnail;
+
+  /// 필수 제목
+  final String title;
+
+  /// 필수 설명
+  final String description;
+
+  /// 선택적 trailing 위젯
+  final Widget? trailing;
+
+  /// 탭 콜백
+  final VoidCallback? onTap;
+
+  /// 품절 상태
+  final bool isSoldOut;
+
+  // 성능 최적화: 정적 스타일들을 미리 생성
+  static const TextStyle _titleStyle = WdsTypography.body14NormalMedium;
+  static const TextStyle _descriptionStyle = WdsTypography.body13NormalRegular;
+
+  static const SizedBox _thumbnailSpacing = SizedBox(width: 4);
+  static const SizedBox _contentSpacing = SizedBox(width: 10);
+  static const SizedBox _titleSpacing = SizedBox(height: 4);
+  static const SizedBox _trailingSpacing = SizedBox(width: 4);
+
+  @override
+  Widget build(BuildContext context, WdsOptionVariant variant) {
+    assert(
+      variant == WdsOptionVariant.product,
+      'ProductOptionItem은 product variant에서만 사용 가능합니다',
+    );
+
+    return GestureDetector(
+      onTap: onTap,
+      child: Row(
+        children: [
+          /// 좌측 영역: index + thumbnail (고정 크기 86x64)
+          SizedBox(
+            width: 86,
+            height: 64,
+            child: Row(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                /// Index (고정 크기 18x20)
+                SizedBox(
+                  width: 18,
+                  height: 20,
+                  child: Text(
+                    index,
+                    style: _titleStyle.copyWith(
+                      color: isSoldOut
+                          ? WdsColors.textDisable
+                          : WdsColors.textNormal,
+                    ),
+                    textAlign: TextAlign.center,
+                  ),
+                ),
+                _thumbnailSpacing,
+
+                /// Thumbnail (나머지 공간)
+                Expanded(
+                  child: isSoldOut
+                      ? Opacity(
+                          opacity: WdsOpacity.opacity40,
+                          child: thumbnail,
+                        )
+                      : thumbnail,
+                ),
+              ],
+            ),
+          ),
+
+          _contentSpacing,
+
+          /// 우측 영역: title + description (Expanded)
+          Expanded(
+            child: Column(
+              mainAxisAlignment: MainAxisAlignment.center,
+              crossAxisAlignment: CrossAxisAlignment.stretch,
+              children: [
+                /// Title + Trailing
+                Row(
+                  children: [
+                    Expanded(
+                      child: Text(
+                        title,
+                        style: _titleStyle.copyWith(
+                          color: isSoldOut
+                              ? WdsColors.textDisable
+                              : WdsColors.textNormal,
+                        ),
+                        maxLines: 1,
+                        overflow: TextOverflow.ellipsis,
+                      ),
+                    ),
+                    if (trailing != null) ...[
+                      _trailingSpacing,
+                      trailing!,
+                    ],
+                  ],
+                ),
+                _titleSpacing,
+
+                /// Description
+                Text(
+                  description,
+                  style: _descriptionStyle.copyWith(
+                    color: isSoldOut
+                        ? WdsColors.textDisable
+                        : WdsColors.textAlternative,
+                  ),
+                  maxLines: 1,
+                  overflow: TextOverflow.ellipsis,
+                ),
+              ],
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/packages/components/lib/src/option/wds_option.dart
+++ b/packages/components/lib/src/option/wds_option.dart
@@ -284,8 +284,8 @@ class WdsPowerOptionItem extends WdsOptionItem {
               WdsChip.pill(
                 onTap: onTap,
                 label: '알림받는중',
-                value: 'r',
-                groupValues: {},
+                value: 1,
+                groupValues: {1},
                 size: WdsChipSize.xsmall,
                 variant: WdsChipVariant.solid,
               )
@@ -293,7 +293,7 @@ class WdsPowerOptionItem extends WdsOptionItem {
               WdsChip.pill(
                 onTap: onTap,
                 label: '입고알림',
-                value: 'ㄴ',
+                value: 0,
                 groupValues: {},
                 size: WdsChipSize.xsmall,
               ),

--- a/packages/components/lib/src/select/wds_select.dart
+++ b/packages/components/lib/src/select/wds_select.dart
@@ -66,11 +66,22 @@ class _WdsSelectState extends State<WdsSelect> {
       color: _textColor(),
     );
 
-    final decoration = ShapeDecoration(
+    final borderSide = _borderSide();
+    const radius = Radius.circular(WdsRadius.sm);
+
+    final decoration = BoxDecoration(
       color: _backgroundColor(),
-      shape: RoundedRectangleBorder(
-        borderRadius: const BorderRadius.all(Radius.circular(WdsRadius.sm)),
-        side: _borderSide(),
+      border: Border(
+        top: borderSide,
+        left: borderSide,
+        right: borderSide,
+        bottom: widget.isExpanded ? BorderSide.none : borderSide,
+      ),
+      borderRadius: BorderRadius.only(
+        topLeft: radius,
+        topRight: radius,
+        bottomLeft: widget.isExpanded ? Radius.zero : radius,
+        bottomRight: widget.isExpanded ? Radius.zero : radius,
       ),
     );
 

--- a/packages/components/lib/src/tag/wds_tag.dart
+++ b/packages/components/lib/src/tag/wds_tag.dart
@@ -49,6 +49,30 @@ class WdsTag extends StatelessWidget {
         backgroundColor = WdsColors.secondary,
         hasRadius = false;
 
+  const WdsTag.$soldOut({super.key})
+      : label = '임시품절',
+        color = WdsColors.white,
+        backgroundColor = WdsColors.coolNeutral300,
+        hasRadius = true;
+
+  const WdsTag.$myPower({super.key})
+      : label = '내 도수',
+        color = WdsColors.textNeutral,
+        backgroundColor = WdsColors.neutral50,
+        hasRadius = true;
+
+  const WdsTag.$barodrim({super.key})
+      : label = '바로드림',
+        color = WdsColors.statusPositive,
+        backgroundColor = WdsColors.neutral50,
+        hasRadius = true;
+
+  const WdsTag.$upto2days({super.key})
+      : label = '1~2일예상',
+        color = WdsColors.textNeutral,
+        backgroundColor = WdsColors.neutral50,
+        hasRadius = true;
+
   static const double fixedHeight = 18;
 
   static const EdgeInsets fixedPadding = EdgeInsets.symmetric(

--- a/packages/components/lib/src/tag/wds_tag.dart
+++ b/packages/components/lib/src/tag/wds_tag.dart
@@ -50,7 +50,7 @@ class WdsTag extends StatelessWidget {
         hasRadius = false;
 
   const WdsTag.$soldOut({super.key})
-      : label = '임시품절',
+      : label = '일시품절',
         color = WdsColors.white,
         backgroundColor = WdsColors.coolNeutral300,
         hasRadius = true;

--- a/packages/components/lib/wds_components.dart
+++ b/packages/components/lib/wds_components.dart
@@ -29,6 +29,7 @@ part 'src/icon/wds_icon_button.dart';
 part 'src/item_card/wds_item_card.dart';
 part 'src/loading/wds_loading.dart';
 part 'src/navigation/wds_bottom_navigation.dart';
+part 'src/option/wds_option.dart';
 part 'src/pagination/wds_count_pagination.dart';
 part 'src/pagination/wds_dot_pagination.dart';
 part 'src/radio/wds_radio.dart';

--- a/packages/widgetbook/lib/main.directories.g.dart
+++ b/packages/widgetbook/lib/main.directories.g.dart
@@ -40,6 +40,8 @@ import 'package:wds_widgetbook/src/component/item_card_use_case.dart'
     as _wds_widgetbook_src_component_item_card_use_case;
 import 'package:wds_widgetbook/src/component/loading_use_case.dart'
     as _wds_widgetbook_src_component_loading_use_case;
+import 'package:wds_widgetbook/src/component/option_use_case.dart'
+    as _wds_widgetbook_src_component_option_use_case;
 import 'package:wds_widgetbook/src/component/radio_use_case.dart'
     as _wds_widgetbook_src_component_radio_use_case;
 import 'package:wds_widgetbook/src/component/search_field_use_case.dart'
@@ -185,11 +187,11 @@ final directories = <_widgetbook.WidgetbookNode>[
         ),
       ),
       _widgetbook.WidgetbookLeafComponent(
-        name: 'Loading',
+        name: 'Option',
         useCase: _widgetbook.WidgetbookUseCase(
-          name: 'Loading',
-          builder: _wds_widgetbook_src_component_loading_use_case
-              .buildLoadingUseCase,
+          name: 'Option',
+          builder: _wds_widgetbook_src_component_option_use_case
+              .buildWdsOptionUseCase,
         ),
       ),
       _widgetbook.WidgetbookLeafComponent(
@@ -333,6 +335,14 @@ final directories = <_widgetbook.WidgetbookNode>[
           name: 'Tooltip',
           builder: _wds_widgetbook_src_component_tooltip_use_case
               .buildWdsTooltipUseCase,
+        ),
+      ),
+      _widgetbook.WidgetbookLeafComponent(
+        name: 'WdsLoading',
+        useCase: _widgetbook.WidgetbookUseCase(
+          name: 'Loading',
+          builder: _wds_widgetbook_src_component_loading_use_case
+              .buildLoadingUseCase,
         ),
       ),
     ],

--- a/packages/widgetbook/lib/src/component/option_use_case.dart
+++ b/packages/widgetbook/lib/src/component/option_use_case.dart
@@ -1,0 +1,193 @@
+import 'package:wds_widgetbook/src/widgetbook_components/widgetbook_components.dart'
+    hide Icon;
+import 'package:widgetbook/widgetbook.dart';
+import 'package:widgetbook_annotation/widgetbook_annotation.dart' as widgetbook;
+
+@widgetbook.UseCase(
+  name: 'Option',
+  type: Option,
+  path: '[component]/',
+)
+Widget buildWdsOptionUseCase(BuildContext context) {
+  return WidgetbookPageLayout(
+    title: 'Option',
+    description: 'Select 영역에서 원하는 옵션을 선택할 수 있도록 돕는 컴포넌트',
+    children: [
+      _buildPlaygroundSection(context),
+      const SizedBox(height: 32),
+      _buildDemonstrationSection(context),
+    ],
+  );
+}
+
+Widget _buildPlaygroundSection(BuildContext context) {
+  final variant = context.knobs.object.dropdown<WdsOptionVariant>(
+    label: 'variant',
+    options: WdsOptionVariant.values,
+    initialOption: WdsOptionVariant.power,
+    labelBuilder: (v) => v.name,
+  );
+
+  final itemCount = context.knobs.int.slider(
+    label: 'count',
+    initialValue: 3,
+    min: 1,
+    max: 10,
+    divisions: 9,
+    description: '옵션의 개수를 설정할 수 있어요',
+  );
+
+  final items = _generateOptionItems(variant, itemCount);
+
+  return WidgetbookPlayground(
+    info: [
+      'Variant: ${variant.name}',
+      'Item Count: $itemCount',
+      'Max Height: ${variant.maxHeight}px',
+      'Scroll Threshold: ${variant.scrollThreshold}',
+      'Item Height: ${variant.itemHeight}px',
+    ],
+    child: variant == WdsOptionVariant.power
+        ? WdsOption.power(items: items)
+        : WdsOption.product(items: items),
+  );
+}
+
+Widget _buildDemonstrationSection(BuildContext context) {
+  const String imagePath =
+      'https://cdn.winc.app/uploads/ppb/image/src/60563/ppb_image_file-c9a9df.jpg';
+
+  return WidgetbookSection(
+    title: 'Option',
+    children: [
+      WidgetbookSubsection(
+        title: 'variant',
+        labels: ['power', 'product'],
+        content: Column(
+          spacing: 16,
+          children: [
+            WdsOption.power(
+              items: [
+                WdsPowerOptionItem(
+                  label: '-0.50',
+                  onTap: () => debugPrint('Power option A tapped'),
+                ),
+                WdsPowerOptionItem(
+                  label: '-0.75',
+                  tags: const [
+                    WdsTag.$barodrim(),
+                    WdsTag.$myPower(),
+                  ],
+                  onTap: () => debugPrint('Power option B tapped'),
+                ),
+                WdsPowerOptionItem(
+                  label: '-1.00',
+                  tags: const [
+                    WdsTag.$upto2days(),
+                    WdsTag.$myPower(),
+                  ],
+                  onTap: () => debugPrint('Power option C tapped'),
+                ),
+                WdsPowerOptionItem(
+                  label: '-1.25',
+                  isSoldOut: true,
+                  onTap: () => debugPrint('Sold out option tapped'),
+                ),
+                WdsPowerOptionItem(
+                  label: '-1.50',
+                  isSoldOut: true,
+                  tags: const [WdsTag.$myPower()],
+                  hasRegistered: true,
+                  onTap: () => debugPrint('Sold out option tapped'),
+                ),
+              ],
+            ),
+            WdsOption.product(
+              items: [
+                WdsProductOptionItem(
+                  index: '1',
+                  thumbnail: const ClipRRect(
+                    borderRadius:
+                        BorderRadius.all(Radius.circular(WdsRadius.xs)),
+                    child: WdsThumbnail.xxs(
+                      imagePath: imagePath,
+                    ),
+                  ),
+                  title: '아이엠 크리스틴 원데이 로우브라운',
+                  description: '하루용 13.0mm',
+                  onTap: () => debugPrint('Product option 1 tapped'),
+                ),
+                WdsProductOptionItem(
+                  index: '2',
+                  thumbnail: const ClipRRect(
+                    borderRadius:
+                        BorderRadius.all(Radius.circular(WdsRadius.xs)),
+                    child: WdsThumbnail.xxs(
+                      imagePath: imagePath,
+                    ),
+                  ),
+                  title: '아이엠 크리스틴 원데이 로우브라운',
+                  description: '하루용 13.0mm',
+                  trailing: const WdsTag.$soldOut(),
+                  isSoldOut: true,
+                  onTap: () => debugPrint('Product option 1 tapped'),
+                ),
+              ],
+            ),
+          ],
+        ),
+      ),
+    ],
+  );
+}
+
+List<WdsOptionItem> _generateOptionItems(
+  WdsOptionVariant variant,
+  int count,
+) {
+  const String imagePath =
+      'https://cdn.winc.app/uploads/ppb/image/src/99824/ppb_image_file-c9a9df.jpg';
+
+  if (variant == WdsOptionVariant.power) {
+    return List.generate(count, (index) {
+      final label = index == 0 ? '0.00' : (-0.5 * index).toStringAsFixed(2);
+      final hasTags = index % 3 == 1;
+      final isSoldOut = index == count - 1;
+
+      return WdsPowerOptionItem(
+        label: label,
+        tags: hasTags
+            ? [
+                if (index.isEven) ...[
+                  const WdsTag.$barodrim(),
+                  const WdsTag.$myPower(),
+                ],
+                if (index % 3 == 0) ...[
+                  const WdsTag.$upto2days(),
+                  const WdsTag.$myPower(),
+                ],
+              ]
+            : [],
+        isSoldOut: isSoldOut,
+        onTap: () => debugPrint('Power option $label tapped'),
+      );
+    });
+  } else {
+    return List.generate(count, (index) {
+      return WdsProductOptionItem(
+        index: '${index + 1}',
+        thumbnail: const ClipRRect(
+          borderRadius: BorderRadius.all(Radius.circular(WdsRadius.xs)),
+          child: WdsThumbnail.xxs(
+            imagePath: imagePath,
+          ),
+        ),
+        title: '돌리 크리스틴 초코',
+        description: '하루용 13.0mm',
+        trailing: index.isEven ? const WdsTag.$soldOut() : null,
+        isSoldOut: index.isEven,
+        onTap: () => debugPrint('Product option ${index + 1} tapped'),
+      );
+    });
+  }
+}

--- a/packages/widgetbook/lib/src/widgetbook_components/widgetbook_components.dart
+++ b/packages/widgetbook/lib/src/widgetbook_components/widgetbook_components.dart
@@ -115,3 +115,6 @@ class Thumbnail {}
 
 /// 컴포넌트 path 관리를 위한 클래스
 class Tag {}
+
+/// 컴포넌트 path 관리를 위한 클래스
+class Option {}


### PR DESCRIPTION
## ✅ 주요 변경 요약

### 1. **새로운 Option 컴포넌트 구현**
* Option 컴포넌트 추가 및 문서화
  * `docs/wds_component_guide.md`에 Option 컴포넌트의 구조, 변형(`power`, `product`), 스타일링 규칙, 품절 등 다양한 상태 동작 상세 문서화
  * 코드베이스 전반에서 사용 가능하도록 디자인 시스템 엔트리포인트(`wds_components.dart`)에 Option 컴포넌트 구현 및 등록

---

### 2. **Widgetbook 통합 및 데모**
* Option 컴포넌트 유스케이스 추가
  * 상호작용 테스트를 위한 플레이그라운드 및 다양한 옵션 아이템 구성을 보여주는 시연 섹션 포함
  * widgetbook 등록 및 디렉토리 업데이트로 완전한 통합

---

### 3. **Tag 컴포넌트 기능 확장**
* 새로운 Tag 변형 추가
  * `WdsTag` 컴포넌트에 `$soldOut`, `$myPower`, `$barodrim`, `$upto2days` 등 새로운 변형 도입
  * 옵션 아이템 내에서 사용할 수 있는 고유한 스타일링 및 라벨 제공

---

### 4. **Select 컴포넌트 보더 로직 개선**
* Select 컴포넌트의 보더 렌더링 업데이트
  * 조건부 border radius 및 border sides를 사용한 `BoxDecoration` 활용
  * select가 확장된 상태에서 올바른 외관 보장

---

## 📋 **주요 변경 포인트**
* **옵션 선택을 위한 전문화된 컴포넌트로 사용자 인터페이스 확장**
* **다양한 상태 및 변형을 지원하는 유연한 옵션 아이템 구현**
* **옵션 내에서 사용할 수 있는 특화된 태그 변형으로 정보 표시 강화**
* **Select 컴포넌트의 시각적 일관성 개선**

---

## ☑️ **마이그레이션/배포 체크리스트**
* Option 컴포넌트의 `power` 및 `product` 변형이 올바른 구조와 스타일로 렌더링되는지 확인
* 품절 상태 등 다양한 Option 상태가 시각적으로 명확하게 구분되는지 테스트
* 새로운 Tag 변형들(`$soldOut`, `$myPower`, `$barodrim`, `$upto2days`)이 올바른 스타일링과 라벨로 표시되는지 검증
* Widgetbook에서 Option 플레이그라운드가 모든 변형과 상태를 정상적으로 시연하는지 확인
* Select 컴포넌트의 업데이트된 보더 로직이 확장/축소 상태에서 올바르게 작동하는지 테스트
* Option 컴포넌트가 `wds_components.dart`에서 정상적으로 export되고 import 가능한지 검증
* 문서화된 Option 속성과 실제 구현이 정확히 일치하는지 확인
* Tag와 Option의 조합이 시각적으로 일관되고 조화롭게 표시되는지 테스트
* Select의 새로운 보더 로직이 다양한 테마와 상태에서 적절히 작동하는지 검증
* Option 컴포넌트의 접근성 기준 충족 여부 확인