### PR TITLE
Feat: MenuItem 추가

### DIFF
--- a/docs/wds_component_guide.md
+++ b/docs/wds_component_guide.md
@@ -2589,3 +2589,68 @@ Selected (선택됨) | `WdsTypography.body13NormalBold` | `WdsColors.white` | `W
 --- | --- | ---
 size | int | 원형 로더의 크기 조정 가능
 color | WdsColors | 로더의 색상 변경 가능
+
+## MenuItem
+
+> 텍스트 기반 선택 요소 정보를 섹션 또는 그룹으로 나눌 수 있는 연속적인 수직 집합체입니다. 대량의 정보를 목록 형태로 깨끗하고 효율적으로 정리할 수 있습니다.
+
+MenuItem은 아래 속성으로 이루어집니다.
+
+속성 | Type | 비고
+--- | --- | --- 
+text | `String` | 메뉴 아이템에 표시될 텍스트 내용
+icon | `bool` | 아이콘 표시 여부 (`true` 시 chevron 아이콘 표시)
+onTap | `VoidCallback?` | 메뉴 아이템이 눌렸을 때 콜백 (선택사항)
+
+### MenuItem - 고정된 속성
+
+모든 MenuItem은 동일한 시각적 속성을 갖습니다.
+
+속성 | 값 | 비고
+--- | --- | ---
+padding | `EdgeInsets.symmetric(horizontal: 16, vertical: 14)` | 고정
+typography | `WdsTypography.body15NormalMedium` | 
+textColor | `WdsColors.textNormal` | enabled 상태
+
+### MenuItem - icon
+
+아이콘이 표시되는 경우의 속성입니다.
+
+속성 | 값 | 비고
+--- | --- | ---
+iconSize | 20x20px | 고정 크기
+iconColor | `WdsColors.neutral300` | 아이콘 색상
+iconSpacing | 16px | 텍스트와 아이콘 사이 간격
+
+### MenuItem - layout
+
+icon 여부에 따라 레이아웃 구조가 달라집니다.
+
+**icon = false**
+```
+DecoratedBox > Padding > (Expanded > Text)
+```
+
+**icon = true**
+```
+DecoratedBox > Padding > Row: (Expanded > Text) + SizedBox(16px) + WdsIcon
+```
+
+### MenuItem - 생성 방법
+
+named constructor로 생성할 수 있습니다.
+
+``` dart
+// 아이콘 없는 메뉴 아이템
+WdsMenuItem.text(
+  text: '텍스트',
+  onTap: () => print('메뉴 선택'),
+)
+
+// 아이콘 있는 메뉴 아이템
+WdsMenuItem.icon(
+  text: '텍스트',
+  onTap: () => print('메뉴 선택'),
+)
+
+```

--- a/packages/components/lib/src/menu_item/wds_menu_item.dart
+++ b/packages/components/lib/src/menu_item/wds_menu_item.dart
@@ -1,0 +1,133 @@
+part of '../../wds_components.dart';
+
+class WdsMenuItem extends StatefulWidget {
+  const WdsMenuItem.text({
+    required this.text,
+    required this.onTap,
+    super.key,
+  }) : icon = null;
+
+  const WdsMenuItem.icon({
+    required this.text,
+    required this.icon,
+    required this.onTap,
+    super.key,
+  });
+
+  final String text;
+
+  final WdsIcon? icon;
+
+  final VoidCallback onTap;
+
+  @override
+  State<WdsMenuItem> createState() => _WdsMenuItemState();
+}
+
+class _WdsMenuItemState extends State<WdsMenuItem> {
+  bool _isPressed = false;
+  bool _isHovered = false;
+
+  static const Duration _hoverAnimationDuration = Duration(milliseconds: 150);
+
+  void _handleTapDown(TapDownDetails details) {
+    setState(() => _isPressed = true);
+  }
+
+  void _handleTapUp(TapUpDetails details) {
+    _handleTapEnd();
+  }
+
+  void _handleTapCancel() {
+    _handleTapEnd();
+  }
+
+  void _handleTapEnd() {
+    if (_isPressed) {
+      setState(() => _isPressed = false);
+    }
+  }
+
+  Color _overlayTargetColor() {
+    final Color base = WdsColors.cta.withAlpha(WdsOpacity.opacity10.toAlpha());
+    if (_isPressed || _isHovered) return base;
+    return Colors.transparent;
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final overlay = TweenAnimationBuilder<Color?>(
+      duration: _hoverAnimationDuration,
+      tween: ColorTween(end: _overlayTargetColor()),
+      curve: Curves.easeInOut,
+      builder: (context, color, _) {
+        return DecoratedBox(
+          decoration: BoxDecoration(
+            color: color,
+          ),
+        );
+      },
+    );
+
+    final content = Padding(
+      padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 14),
+      child: Row(
+        children: [
+          Expanded(
+            child: Text(
+              widget.text,
+              maxLines: 1,
+              style: WdsTypography.body15NormalMedium.copyWith(
+                color: WdsColors.textNormal,
+              ),
+              overflow: TextOverflow.ellipsis,
+            ),
+          ),
+          if (widget.icon != null) ...[
+            const SizedBox(width: 16),
+            widget.icon!.build(
+              width: 20,
+              height: 20,
+              color: WdsColors.neutral300,
+            ),
+          ],
+        ],
+      ),
+    );
+
+    final coreGesture = GestureDetector(
+      onTapDown: _handleTapDown,
+      onTapUp: _handleTapUp,
+      onTapCancel: _handleTapCancel,
+      onTap: widget.onTap,
+      behavior: HitTestBehavior.opaque,
+      child: Stack(
+        alignment: Alignment.center,
+        children: [
+          Positioned.fill(child: overlay),
+          content,
+        ],
+      ),
+    );
+
+    final gestureChild = kIsWeb
+        ? MouseRegion(
+            onEnter: (_) {
+              if (!mounted) return;
+              if (!_isHovered) {
+                setState(() => _isHovered = true);
+              }
+            },
+            onExit: (_) {
+              if (!mounted) return;
+              if (_isHovered) {
+                setState(() => _isHovered = false);
+              }
+            },
+            child: coreGesture,
+          )
+        : coreGesture;
+
+    return gestureChild;
+  }
+}

--- a/packages/components/lib/wds_components.dart
+++ b/packages/components/lib/wds_components.dart
@@ -11,7 +11,8 @@ import 'package:flutter/material.dart'
         UnderlineInputBorder,
         TextSelectionTheme,
         TextSelectionThemeData,
-        CircularProgressIndicator;
+        CircularProgressIndicator,
+        Colors;
 import 'package:flutter/widgets.dart';
 import 'package:wds_foundation/wds_foundation.dart';
 
@@ -30,6 +31,7 @@ part 'src/heading/wds_heading.dart';
 part 'src/icon/wds_icon_button.dart';
 part 'src/item_card/wds_item_card.dart';
 part 'src/loading/wds_loading.dart';
+part 'src/menu_item/wds_menu_item.dart';
 part 'src/navigation/wds_bottom_navigation.dart';
 part 'src/pagination/wds_count_pagination.dart';
 part 'src/pagination/wds_dot_pagination.dart';

--- a/packages/widgetbook/lib/main.directories.g.dart
+++ b/packages/widgetbook/lib/main.directories.g.dart
@@ -42,6 +42,8 @@ import 'package:wds_widgetbook/src/component/item_card_use_case.dart'
     as _wds_widgetbook_src_component_item_card_use_case;
 import 'package:wds_widgetbook/src/component/loading_use_case.dart'
     as _wds_widgetbook_src_component_loading_use_case;
+import 'package:wds_widgetbook/src/component/menu_item_use_case.dart'
+    as _wds_widgetbook_src_component_menu_item_use_case;
 import 'package:wds_widgetbook/src/component/radio_use_case.dart'
     as _wds_widgetbook_src_component_radio_use_case;
 import 'package:wds_widgetbook/src/component/search_field_use_case.dart'
@@ -202,6 +204,14 @@ final directories = <_widgetbook.WidgetbookNode>[
           name: 'Loading',
           builder: _wds_widgetbook_src_component_loading_use_case
               .buildLoadingUseCase,
+        ),
+      ),
+      _widgetbook.WidgetbookLeafComponent(
+        name: 'MenuItem',
+        useCase: _widgetbook.WidgetbookUseCase(
+          name: 'MenuItem',
+          builder: _wds_widgetbook_src_component_menu_item_use_case
+              .buildWdsMenuItemUseCase,
         ),
       ),
       _widgetbook.WidgetbookLeafComponent(

--- a/packages/widgetbook/lib/src/component/menu_item_use_case.dart
+++ b/packages/widgetbook/lib/src/component/menu_item_use_case.dart
@@ -1,0 +1,94 @@
+import 'package:wds_widgetbook/src/widgetbook_components/widgetbook_components.dart';
+import 'package:widgetbook/widgetbook.dart';
+import 'package:widgetbook_annotation/widgetbook_annotation.dart' as widgetbook;
+
+@widgetbook.UseCase(
+  name: 'MenuItem',
+  type: WdsMenuItem,
+  path: '[component]/',
+)
+Widget buildWdsMenuItemUseCase(BuildContext context) {
+  return WidgetbookPageLayout(
+    title: 'MenuItem',
+    description: '텍스트 기반 선택 요소 정보를 섹션 또는 그룹으로 나눌 수 있는 연속적인 수직 집합체입니다.',
+    children: [
+      _buildPlaygroundSection(context),
+      _buildDemonstrationSection(context),
+    ],
+  );
+}
+
+Widget _buildPlaygroundSection(BuildContext context) {
+  final iconType = context.knobs.object.dropdown<String>(
+    label: 'icon',
+    options: [
+      'blank',
+      'arrowRight',
+      'arrowDown',
+      'arrowUp',
+      'arrowLeft',
+    ],
+    initialOption: 'blank',
+    description: '아이콘을 선택해요',
+  );
+
+  final text = context.knobs.string(
+    label: 'text',
+    initialValue: '텍스트',
+    description: '메뉴 아이템에 표시될 텍스트를 정의해요',
+  );
+
+  final icon = switch (iconType) {
+    'arrowRight' => WdsIcon.chevronRight,
+    'arrowDown' => WdsIcon.chevronDown,
+    'arrowUp' => WdsIcon.chevronUp,
+    'arrowLeft' => WdsIcon.chevronLeft,
+    _ => null,
+  };
+
+  return WidgetbookPlayground(
+    info: [
+      'Text: $text',
+      'Icon: ${iconType == 'none' ? 'None' : iconType}',
+    ],
+    child: icon != null
+        ? WdsMenuItem.icon(
+            text: text,
+            icon: icon,
+            onTap: () {},
+          )
+        : WdsMenuItem.text(
+            text: text,
+            onTap: () {},
+          ),
+  );
+}
+
+Widget _buildDemonstrationSection(BuildContext context) {
+  return WidgetbookSection(
+    title: 'MenuItem',
+    children: [
+      WidgetbookSubsection(
+        title: 'variant',
+        labels: [
+          'text',
+          'icon',
+        ],
+        content: Column(
+          spacing: 8,
+          children: [
+            WdsMenuItem.text(
+              text: '텍스트만 있는 메뉴 아이템',
+              onTap: () {},
+            ),
+            WdsMenuItem.icon(
+              text: '오른쪽 화살표 아이콘 메뉴 아이템',
+              icon: WdsIcon.chevronRight,
+              onTap: () {},
+            ),
+          ],
+        ),
+      ),
+    ],
+  );
+}


### PR DESCRIPTION
## ✅ 주요 변경 요약

### 1. 새로운 `MenuItem` 컴포넌트 구현
- `WdsMenuItem` 위젯 추가
- `text·icon` 두 가지 생성자 제공
- 아이콘 옵션 지원, 탭 이벤트 핸들링 가능
- `Hover` 및 `Press` 시 시각적 피드백 제공

### 2.문서화
- `docs/wds_component_guide.md`에 `MenuItem` 사용법, 속성, 레이아웃, 예제 코드 상세 추가
- `Widgetbook` 통합 및 데모
- `MenuItem` 전용 `use case` 파일 추가 (`menu_item_use_case.dart`)
- 상호작용 `Playground`와 속성 조작 기능 제공

## 📋 주요 변경 포인트
- 일관된 스타일과 접근성을 갖춘 재사용 가능한 `MenuItem` 컴포넌트 추가
- 텍스트/아이콘 옵션을 분리된 생성자로 제공 → 다양한 메뉴 패턴에 대응
- 문서 및 `Widgetbook` 예제를 통해 개발자-디자이너 간 동일한 이해도 확보

## ☑️ 마이그레이션/배포 체크리스트
- `WdsMenuItem.text`, `WdsMenuItem.icon` 두 생성자가 정상 동작하는지 검증
- `Hover/Press` 상태에서 시각적 피드백이 의도대로 표시되는지 확인
- 아이콘 없는 경우 레이아웃이 올바르게 정렬되는지 테스트
- 문서화된 사용 예제가 실제 구현과 일치하는지 확인
- `Widgetbook`에서 모든 옵션과 `Playground`가 정상 동작하는지 검증