### PR TITLE
Fix: Divider > variant thick color 수정

### DIFF
--- a/packages/components/lib/src/divider/wds_divider.dart
+++ b/packages/components/lib/src/divider/wds_divider.dart
@@ -36,18 +36,21 @@ class WdsDivider extends StatelessWidget {
       );
     }
 
-    // 가로: width infinity, height variant 에 따라 1px | 6px
-    final double height = switch (variant) {
-      WdsDividerVariant.normal => 1,
-      WdsDividerVariant.thick => 6,
+    return switch (variant) {
+      WdsDividerVariant.normal => const SizedBox(
+          width: double.infinity,
+          height: 1,
+          child: DecoratedBox(
+            decoration: BoxDecoration(color: WdsColors.borderAlternative),
+          ),
+        ),
+      WdsDividerVariant.thick => const SizedBox(
+          width: double.infinity,
+          height: 6,
+          child: DecoratedBox(
+            decoration: BoxDecoration(color: WdsColors.backgroundAlternative),
+          ),
+        ),
     };
-
-    return SizedBox(
-      width: double.infinity,
-      height: height,
-      child: const DecoratedBox(
-        decoration: BoxDecoration(color: WdsColors.borderAlternative),
-      ),
-    );
   }
 }


### PR DESCRIPTION
이 PR은 `WdsDivider` 위젯의 thick 변형의 색상을 조정 및 const 최적화 진행

### 주요 변경 사항

build 메서드를 switch 표현식으로 리팩터링 → const 최적화 및 코드 간결, 확장성 향상

thick variant 색상을 `WdsColors.borderAlternative` → `WdsColors.backgroundAlternative` 로 변경 