### PR TITLE
Fix: Option, WdsProductOptionItem 내 title 과 trailing 간격 수정

### DIFF
--- a/packages/components/lib/src/option/wds_option.dart
+++ b/packages/components/lib/src/option/wds_option.dart
@@ -404,7 +404,7 @@ class WdsProductOptionItem extends WdsOptionItem {
                 /// Title + Trailing
                 Row(
                   children: [
-                    Expanded(
+                    Flexible(
                       child: Text(
                         title,
                         style: _titleStyle.copyWith(


### PR DESCRIPTION
## ✅ 주요 변경 요약

### 1. **WdsProductOptionItem 레이아웃 개선**
* 텍스트 위젯 레이아웃 유연성 향상
  * 제목을 표시하는 `Text` 위젯에서 `Expanded`를 `Flexible`로 교체
  * 특정 레이아웃 시나리오에서 더 나은 레이아웃 유연성 제공

---

## 📋 **주요 변경 포인트**
* **레이아웃 제약 조건 완화로 더 유연한 텍스트 표시**

---

## ☑️ **마이그레이션/배포 체크리스트**
* `WdsProductOptionItem`에서 제목 텍스트가 다양한 길이에서 올바르게 표시되는지 확인
* `Flexible`로 변경된 후 텍스트 오버플로우 처리가 적절히 작동하는지 테스트
* 다양한 화면 크기에서 레이아웃이 예상대로 반응하는지 검증
* 기존 `Expanded` 동작에 의존하던 레이아웃이 영향받지 않는지 확인



<img width="955" height="182" alt="None" src="https://github.com/user-attachments/assets/b5844b4a-0e24-4709-aa09-b64da9ca23f7" />

<img width="288" alt="iPhone12 - 1" src="https://github.com/user-attachments/assets/94defcdc-7148-4324-a4bb-d5ca9392c4d9" />

<img width="288" alt="iPhone12 - 2" src="https://github.com/user-attachments/assets/b2da4466-c789-46bf-a746-7af33c67c2c0" />
