### PR TITLE
Fix: Tag에 leadingIcon 추가

### DIFF
--- a/packages/components/lib/src/tag/wds_tag.dart
+++ b/packages/components/lib/src/tag/wds_tag.dart
@@ -7,12 +7,14 @@ class WdsTag extends StatelessWidget {
     this.backgroundColor = WdsColors.neutral50,
     this.color = WdsColors.textNeutral,
     this.hasRadius = true,
+    this.leadingIcon,
     super.key,
   });
 
   const WdsTag.normal({
     required this.label,
     this.hasRadius = true,
+    this.leadingIcon,
     super.key,
   })  : backgroundColor = WdsColors.neutral50,
         color = WdsColors.textNeutral;
@@ -20,6 +22,7 @@ class WdsTag extends StatelessWidget {
   const WdsTag.filled({
     required this.label,
     this.hasRadius = true,
+    this.leadingIcon,
     super.key,
   })  : backgroundColor = WdsColors.primary,
         color = WdsColors.white;
@@ -29,49 +32,57 @@ class WdsTag extends StatelessWidget {
       : label = 'NEW',
         color = WdsColors.white,
         backgroundColor = WdsColors.primary,
-        hasRadius = false;
+        hasRadius = false,
+        leadingIcon = null;
 
   const WdsTag.$sale({super.key})
       : label = 'SALE',
         color = WdsColors.white,
         backgroundColor = WdsColors.secondary,
-        hasRadius = false;
+        hasRadius = false,
+        leadingIcon = null;
 
   const WdsTag.$best({super.key})
       : label = 'BEST',
         color = WdsColors.white,
         backgroundColor = WdsColors.coolNeutral700,
-        hasRadius = false;
+        hasRadius = false,
+        leadingIcon = null;
 
   const WdsTag.$coupon({super.key})
       : label = '쿠폰사용가능',
         color = WdsColors.white,
         backgroundColor = WdsColors.secondary,
-        hasRadius = false;
+        hasRadius = false,
+        leadingIcon = null;
 
   const WdsTag.$soldOut({super.key})
       : label = '일시품절',
         color = WdsColors.white,
         backgroundColor = WdsColors.coolNeutral300,
-        hasRadius = true;
+        hasRadius = true,
+        leadingIcon = null;
 
   const WdsTag.$myPower({super.key})
       : label = '내 도수',
         color = WdsColors.textNeutral,
         backgroundColor = WdsColors.neutral50,
-        hasRadius = true;
+        hasRadius = true,
+        leadingIcon = null;
 
   const WdsTag.$barodrim({super.key})
       : label = '바로드림',
         color = WdsColors.statusPositive,
         backgroundColor = WdsColors.neutral50,
-        hasRadius = true;
+        hasRadius = true,
+        leadingIcon = null;
 
   const WdsTag.$upto2days({super.key})
       : label = '1~2일예상',
         color = WdsColors.textNeutral,
         backgroundColor = WdsColors.neutral50,
-        hasRadius = true;
+        hasRadius = true,
+        leadingIcon = null;
 
   static const double fixedHeight = 18;
 
@@ -94,8 +105,36 @@ class WdsTag extends StatelessWidget {
 
   final bool hasRadius;
 
+  final WdsIcon? leadingIcon;
+
   @override
   Widget build(BuildContext context) {
+    final label = Text(
+      this.label,
+      style: fixedTypography.copyWith(color: color),
+      textAlign: TextAlign.center,
+    );
+
+    final Widget child;
+    if (leadingIcon != null) {
+      child = Row(
+        mainAxisSize: MainAxisSize.min,
+        spacing: 1,
+        children: [
+          Padding(
+            padding: const EdgeInsets.symmetric(vertical: 0.5),
+            child: SizedBox.square(
+              dimension: 12,
+              child: leadingIcon!.build(),
+            ),
+          ),
+          label,
+        ],
+      );
+    } else {
+      child = label;
+    }
+
     return SizedBox(
       height: fixedHeight,
       child: DecoratedBox(
@@ -105,11 +144,7 @@ class WdsTag extends StatelessWidget {
         ),
         child: Padding(
           padding: fixedPadding,
-          child: Text(
-            label,
-            style: fixedTypography.copyWith(color: color),
-            textAlign: TextAlign.center,
-          ),
+          child: child,
         ),
       ),
     );

--- a/packages/widgetbook/lib/src/component/tag_use_case.dart
+++ b/packages/widgetbook/lib/src/component/tag_use_case.dart
@@ -42,6 +42,12 @@ Widget _buildPlaygroundSection(BuildContext context) {
     initialValue: variant == 'normal' ? WdsColors.textNeutral : WdsColors.white,
   );
 
+  final leadingIcon = context.knobs.objectOrNull.dropdown<WdsIcon>(
+    label: 'leadingIcon',
+    options: WdsIcon.values,
+    labelBuilder: (v) => v.name,
+  );
+
   return WidgetbookPlayground(
     info: [
       'label: $label',
@@ -51,12 +57,14 @@ Widget _buildPlaygroundSection(BuildContext context) {
       'height: ${WdsTag.fixedHeight}px @fixed',
       'padding: ${WdsTag.fixedPadding.horizontal}px @fixed',
       'typography: ${WdsTag.fixedTypography.fontSize}px @fixed',
+      'leadingIcon: ${leadingIcon?.name ?? 'null'}',
     ],
     child: Center(
       child: WdsTag(
         label: label,
         backgroundColor: backgroundColor,
         color: textColor,
+        leadingIcon: leadingIcon,
       ),
     ),
   );
@@ -69,8 +77,8 @@ Widget _buildDemonstrationSection(BuildContext context) {
       WidgetbookSubsection(
         title: 'variant',
         labels: ['normal', 'filled'],
-        content: Row(
-          mainAxisSize: MainAxisSize.min,
+        content: Wrap(
+          spacing: 12,
           children: [
             WdsTag.normal(label: '내 도수보유'),
             SizedBox(width: 16),
@@ -80,63 +88,27 @@ Widget _buildDemonstrationSection(BuildContext context) {
       ),
       SizedBox(height: 24),
       WidgetbookSubsection(
-        title: 'label',
-        labels: ['짧은', '긴 텍스트', '숫자'],
-        content: Row(
-          spacing: 8,
-          mainAxisSize: MainAxisSize.min,
+        title: 'radius',
+        labels: ['true', 'false'],
+        content: Wrap(
+          spacing: 12,
           children: [
-            WdsTag.normal(label: 'NEW'),
-            WdsTag.normal(label: '인기 상품'),
-            WdsTag.normal(label: '123'),
+            WdsTag.normal(label: '텍스트', hasRadius: false),
+            WdsTag.normal(label: '텍스트'),
+            WdsTag.filled(label: '텍스트', hasRadius: false),
+            WdsTag.filled(label: '텍스트'),
           ],
         ),
       ),
       SizedBox(height: 24),
       WidgetbookSubsection(
-        title: 'backgroundColor',
-        labels: ['성공', '경고', '오류'],
-        content: Row(
-          spacing: 8,
-          mainAxisSize: MainAxisSize.min,
+        title: 'icon',
+        labels: ['true', 'false'],
+        content: Wrap(
+          spacing: 12,
           children: [
-            WdsTag(
-              label: '성공',
-              backgroundColor: WdsColors.statusPositive,
-              color: WdsColors.white,
-            ),
-            WdsTag(
-              label: '경고',
-              backgroundColor: WdsColors.statusCautionaty,
-              color: WdsColors.white,
-            ),
-            WdsTag(
-              label: '오류',
-              backgroundColor: WdsColors.statusDestructive,
-              color: WdsColors.white,
-            ),
-          ],
-        ),
-      ),
-      SizedBox(height: 24),
-      WidgetbookSubsection(
-        title: 'color',
-        labels: ['활성', '비활성', '선택됨'],
-        content: Row(
-          spacing: 8,
-          mainAxisSize: MainAxisSize.min,
-          children: [
-            WdsTag.filled(label: '활성'),
-            WdsTag(
-              label: '비활성',
-              backgroundColor: WdsColors.neutral100,
-              color: WdsColors.textDisable,
-            ),
-            WdsTag(
-              label: '선택됨',
-              backgroundColor: WdsColors.blue100,
-              color: WdsColors.primary,
-            ),
+            WdsTag.normal(label: '텍스트', leadingIcon: WdsIcon.blank),
+            WdsTag.normal(label: '텍스트'),
           ],
         ),
       ),

--- a/packages/widgetbook/lib/src/component/tag_use_case.dart
+++ b/packages/widgetbook/lib/src/component/tag_use_case.dart
@@ -81,7 +81,6 @@ Widget _buildDemonstrationSection(BuildContext context) {
           spacing: 12,
           children: [
             WdsTag.normal(label: '내 도수보유'),
-            SizedBox(width: 16),
             WdsTag.filled(label: '바로드림'),
           ],
         ),


### PR DESCRIPTION
## ✅ 주요 변경 요약

### 1. **WdsTag 컴포넌트 기능 강화**
* 선택적 leading icon 지원 추가
  * `WdsTag` 위젯에 선택적 `leadingIcon` 파라미터 추가
  * 라벨 앞에 아이콘 표시 기능 제공
  * 모든 생성자 업데이트 및 위젯 트리에서 조건부 아이콘 렌더링 구현

---

### 2. **플레이그라운드 및 시연 개선**
* 상호작용 플레이그라운드 업데이트
  * `tag_use_case.dart`에서 `leadingIcon`을 상호작용적으로 선택할 수 있도록 개선
  * 태그 정보에 아이콘 값 표시 기능 추가
* 시연 섹션 레이아웃 개선
  * 더 나은 레이아웃을 위해 `Row`를 `Wrap`으로 교체
  * `radius` 및 `icon` 옵션을 보여주는 새로운 하위 섹션 추가
  * leading icon이 있는 경우와 없는 경우의 예제 제공

---

## 📋 **주요 변경 포인트**
* **아이콘 지원으로 태그 컴포넌트의 시각적 표현력 향상**
* **더 유연하고 포괄적인 태그 사용 옵션 제공**
* **개선된 시연 환경으로 컴포넌트 테스트 및 탐색 용이성 증대**

---

## ☑️ **마이그레이션/배포 체크리스트**
* `leadingIcon` 파라미터가 있는 태그와 없는 태그가 모두 올바르게 렌더링되는지 확인
* 다양한 아이콘과 태그 변형의 조합이 시각적으로 조화롭게 표시되는지 테스트
* 플레이그라운드에서 아이콘 선택 기능이 상호작용과 함께 정상 작동하는지 검증
* `Wrap`으로 변경된 레이아웃이 다양한 화면 크기에서 적절히 반응하는지 확인
* 새로운 radius 및 icon 시연 섹션이 모든 옵션을 명확하게 보여

<img width="1002" height="518" alt="image" src="https://github.com/user-attachments/assets/1fb8d5fe-b719-47ec-9cbe-36cce665121f" />
