### PR TITLE
Fix: SquareButton > Variant : Step 추가

### DIFF
--- a/docs/wds_component_guide.md
+++ b/docs/wds_component_guide.md
@@ -239,18 +239,43 @@ Row(
 
 ## SquareButton
 
-버튼과 다르게 SquareButton은 단일 size, typography (색상 제외), padding 이 같은 버튼입니다. 단, state는 아래 2가지로 구분됩니다.
+버튼과 다르게 SquareButton은 단일 size, typography (색상 제외), padding 이 같은 버튼입니다. variant에 따라 레이아웃이 달라지며, state는 아래 2가지로 구분됩니다.
 - `enabled`
 - `disabled`
 
 여기서 `pressed` 는 웹인 경우 hovered 상태도 포함되며 #Button에 구현되어 있는 pressed(hover)와 같은 메커니즘으로 구성됩니다. disabled 일 때 opacity 설정하는 방법도 같습니다.
 
+### SquareButton - variant
+
+정해진 Variant만 사용할 수 있습니다.
+
+- `normal`: 단일 버튼 형태
+- `step`: 3개 버튼이 연결된 형태 (minus, text, plus)
+
 ### SquareButton - 고정된 속성
 속성 | 값
 --- | ---
 size | `Size(double.infinity, 32)`
+radius | `WdsRadius.xs`
+borderSide | `BorderSide(color: WdsColors.borderAlternative)`
 typography | `WdsTypography.caption12Medium`
-padding | `EdgeInsets.symmetric(horizontal: 17, vertical: 8)`
+
+### SquareButton - step variant
+속성 | 값 
+--- | --- 
+padding | `EdgeInsets.symmetric(horizontal: 17, vertical: 8)` 
+
+### SquareButton - step variant
+
+step variant는 3개의 버튼이 연결된 형태로, 좌측부터 minus, text, plus 순서입니다.
+
+속성 | 값 | 비고
+--- | --- | ---
+padding | `EdgeInsets.symmetric(horizontal: 12, vertical: 8)` | -
+spacing | 12px | minus, text, plus 간 간격
+minus icon | `WdsIcon.minus` | 16x16px, `WdsColors.cta`
+plus icon | `WdsIcon.plus` | 16x16px, `WdsColors.cta`
+
 
 ### SquareButton - state
 
@@ -258,6 +283,25 @@ state | backgroundColor | color | radius | borderSide
 --- | --- | --- | --- | --- 
 enabled | WdsColors.white(#FFFFFF) | WdsColors.textNeutral(#4E4E4E) | .v4 | BorderSide(color: WdsColors.borderAlternative)
 disabled | WdsColors.white(#FFFFFF) | WdsColors.textNeutral(#4E4E4E) | .v4 | BorderSide(color: WdsColors.borderAlternative)
+
+### SquareButton - 생성 방법
+
+named constructor로 생성할 수 있습니다.
+
+``` dart
+// 단일 버튼
+WdsSquareButton.normal(
+  text: '텍스트',
+  onTap: () => print('버튼 선택'),
+)
+
+// 3개 연결된 버튼
+WdsSquareButton.step(
+  text: '텍스트',
+  onMinusTap: () => print('-'),
+  onPlusTap: () => print('+'),
+)
+```
 
 ## IconButton
 

--- a/packages/components/lib/src/button/wds_square_button.dart
+++ b/packages/components/lib/src/button/wds_square_button.dart
@@ -1,16 +1,36 @@
 part of '../../wds_components.dart';
 
+enum WdsSquareButtonVariant { normal, step }
+
 /// 고정 규격과 스타일을 갖는 사각형 버튼 (SquareButton)
 class WdsSquareButton extends StatefulWidget {
-  const WdsSquareButton({
-    required this.onTap,
+  const WdsSquareButton.normal({
     required this.child,
+    required this.onTap,
     this.isEnabled = true,
     super.key,
-  });
+  })  : variant = WdsSquareButtonVariant.normal,
+        leadingButton = null,
+        trailingButton = null;
 
-  /// 버튼 탭 콜백 (비활성 시 무시)
+  const WdsSquareButton.step({
+    required this.child,
+    required this.leadingButton,
+    required this.trailingButton,
+    this.isEnabled = true,
+    super.key,
+  })  : variant = WdsSquareButtonVariant.step,
+        onTap = null;
+
+  final WdsSquareButtonVariant variant;
+
   final VoidCallback? onTap;
+
+  /// step variant의 왼쪽 버튼 (WdsIconButton)
+  final Widget? leadingButton;
+
+  /// step variant의 오른쪽 버튼 (WdsIconButton)
+  final Widget? trailingButton;
 
   /// 라벨 위젯 (일반적으로 Text)
   final Widget child;
@@ -63,47 +83,13 @@ class _WdsSquareButtonState extends State<WdsSquareButton>
 
   @override
   Widget build(BuildContext context) {
-    // 문서 명세 (docs/wds_component_guide.md):
-    // size: Size(double.infinity, 32)
-    // typography: WdsTypography.caption12Medium
-    // padding: EdgeInsets.symmetric(horizontal: 17, vertical: 8)
-    // state: enabled/disabled 동일 배경/테두리, disabled 는 opacity 로 표현
     const double height = 32;
-    const EdgeInsets padding = EdgeInsets.fromLTRB(17, 8, 17, 8);
-    final TextStyle typography = WdsTypography.caption12Medium.copyWith(
-      color: WdsColors.textNormal,
-    );
+
     final BorderRadius borderRadius =
         const BorderRadius.all(Radius.circular(WdsRadius.xs));
 
-    // 자식이 Text 인 경우 강제 타이포그래피 적용, 그 외에는 DefaultTextStyle.merge
-    Widget content = Padding(padding: padding, child: widget.child);
-    if (widget.child is Text) {
-      final Text childText = widget.child as Text;
-      final TextStyle merged = childText.style?.merge(typography) ?? typography;
-      content = Padding(
-        padding: padding,
-        child: Text(
-          childText.data ?? '',
-          key: childText.key,
-          style: merged,
-          strutStyle: childText.strutStyle,
-          textAlign: childText.textAlign,
-          textDirection: childText.textDirection,
-          locale: childText.locale,
-          softWrap: childText.softWrap,
-          overflow: childText.overflow,
-          textScaler: childText.textScaler,
-          maxLines: 1,
-          semanticsLabel: childText.semanticsLabel,
-          textWidthBasis: childText.textWidthBasis,
-          textHeightBehavior: childText.textHeightBehavior,
-          selectionColor: childText.selectionColor,
-        ),
-      );
-    } else {
-      content = DefaultTextStyle.merge(style: typography, child: content);
-    }
+    // variant에 따라 content만 다르게 생성
+    final Widget content = _buildContent();
 
     final overlay = TweenAnimationBuilder<Color?>(
       duration: _hoverAnimationDuration,
@@ -123,7 +109,12 @@ class _WdsSquareButtonState extends State<WdsSquareButton>
       onTapDown: widget.isEnabled ? _handleTapDown : null,
       onTapUp: widget.isEnabled ? _handleTapUp : null,
       onTapCancel: widget.isEnabled ? _handleTapCancel : null,
-      onTap: widget.isEnabled ? widget.onTap : null,
+      onTap: widget.isEnabled
+          ? switch (widget.variant) {
+              WdsSquareButtonVariant.normal => widget.onTap,
+              WdsSquareButtonVariant.step => null,
+            }
+          : null,
       behavior: HitTestBehavior.opaque,
       child: ClipRRect(
         borderRadius: borderRadius,
@@ -154,11 +145,12 @@ class _WdsSquareButtonState extends State<WdsSquareButton>
                   // 높이 유지, 폭은 컨텐츠 폭 기준
                   const SizedBox(height: height),
                   // 오버레이 (컨텐츠 폭 기준)
-                  Positioned.fill(
-                    child: IgnorePointer(
-                      child: RepaintBoundary(child: overlay),
+                  if (widget.onTap != null)
+                    Positioned.fill(
+                      child: IgnorePointer(
+                        child: RepaintBoundary(child: overlay),
+                      ),
                     ),
-                  ),
                   // 컨텐츠
                   RepaintBoundary(child: content),
                 ],
@@ -194,5 +186,64 @@ class _WdsSquareButtonState extends State<WdsSquareButton>
       return Opacity(opacity: 0.4, child: result);
     }
     return result;
+  }
+
+  Widget _buildContent() {
+    final TextStyle typography = WdsTypography.caption12Medium.copyWith(
+      color: WdsColors.textNormal,
+    );
+
+    // 자식이 Text 인 경우 강제 타이포그래피 적용, 그 외에는 DefaultTextStyle.merge
+    Widget content = widget.child;
+    if (widget.child is Text) {
+      final Text childText = widget.child as Text;
+      final TextStyle merged = childText.style?.merge(typography) ?? typography;
+      content = Text(
+        childText.data ?? '',
+        key: childText.key,
+        style: merged,
+        strutStyle: childText.strutStyle,
+        textAlign: childText.textAlign,
+        textDirection: childText.textDirection,
+        locale: childText.locale,
+        softWrap: childText.softWrap,
+        overflow: childText.overflow,
+        textScaler: childText.textScaler,
+        maxLines: 1,
+        semanticsLabel: childText.semanticsLabel,
+        textWidthBasis: childText.textWidthBasis,
+        textHeightBehavior: childText.textHeightBehavior,
+        selectionColor: childText.selectionColor,
+      );
+    } else {
+      content = DefaultTextStyle.merge(style: typography, child: content);
+    }
+
+    return switch (widget.variant) {
+      WdsSquareButtonVariant.normal => () {
+          const EdgeInsets padding = EdgeInsets.fromLTRB(17, 8, 17, 8);
+
+          return Padding(
+            padding: padding,
+            child: content,
+          );
+        }(),
+      WdsSquareButtonVariant.step => () {
+          const EdgeInsets padding = EdgeInsets.fromLTRB(16, 8, 16, 8);
+
+          return Padding(
+            padding: padding,
+            child: Row(
+              mainAxisSize: MainAxisSize.min,
+              spacing: 12,
+              children: [
+                widget.leadingButton!,
+                content,
+                widget.trailingButton!,
+              ],
+            ),
+          );
+        }(),
+    };
   }
 }

--- a/packages/widgetbook/lib/src/component/square_button_use_case.dart
+++ b/packages/widgetbook/lib/src/component/square_button_use_case.dart
@@ -19,6 +19,13 @@ Widget buildWdsSquareButtonUseCase(BuildContext context) {
 }
 
 Widget _buildPlaygroundSection(BuildContext context) {
+  final variant = context.knobs.object.dropdown(
+    label: 'variant',
+    options: ['normal', 'step'],
+    initialOption: 'normal',
+    description: '버튼의 variant를 선택해요',
+  );
+
   final isEnabled = context.knobs.boolean(
     label: 'isEnabled',
     initialValue: true,
@@ -31,22 +38,46 @@ Widget _buildPlaygroundSection(BuildContext context) {
     description: '버튼의 텍스트를 정의해요',
   );
 
-  final button = WdsSquareButton(
-    onTap: () => debugPrint('SquareButton pressed'),
-    isEnabled: isEnabled,
-    child: Text(
-      text,
-      style: WdsTypography.caption12Medium,
-    ),
-  );
+  final Widget button;
+
+  final List<String> info;
+
+  if (variant == 'step') {
+    button = WdsSquareButton.step(
+      leadingButton: InkWell(
+        onTap: () => debugPrint('Minus button pressed'),
+        child: WdsIcon.minus.build(
+          color: WdsColors.cta,
+          width: 16,
+          height: 16,
+        ),
+      ),
+      trailingButton: InkWell(
+        onTap: () => debugPrint('Plus button pressed'),
+        child: WdsIcon.plus.build(
+          color: WdsColors.cta,
+          width: 16,
+          height: 16,
+        ),
+      ),
+      isEnabled: isEnabled,
+      child: Text(text),
+    );
+  } else {
+    button = WdsSquareButton.normal(
+      onTap: () => debugPrint('Normal SquareButton pressed'),
+      isEnabled: isEnabled,
+      child: Text(text),
+    );
+  }
+
+  info = [
+    'state: ${isEnabled ? 'enabled' : 'disabled'}',
+    'variant: step',
+  ];
 
   return WidgetbookPlayground(
-    info: [
-      'size: height32 @fixed',
-      'typography: caption12Medium @fixed',
-      'padding: horizontal17, vertical8 @fixed',
-      'state: ${isEnabled ? 'enabled' : 'disabled'}',
-    ],
+    info: info,
     child: button,
   );
 }
@@ -63,13 +94,46 @@ Widget _buildDemonstrationSection(BuildContext context) {
           mainAxisSize: MainAxisSize.min,
           spacing: 16,
           children: [
-            WdsSquareButton(
-              onTap: () => debugPrint('Square enabled'),
+            WdsSquareButton.normal(
+              onTap: () => debugPrint('Normal enabled'),
               child: const Text('텍스트'),
             ),
-            WdsSquareButton(
-              onTap: () => debugPrint('Square disabled'),
+            WdsSquareButton.normal(
+              onTap: () => debugPrint('Normal disabled'),
               isEnabled: false,
+              child: const Text('텍스트'),
+            ),
+          ],
+        ),
+      ),
+      WidgetbookSubsection(
+        title: 'variant',
+        labels: ['normal', 'step'],
+        content: Row(
+          mainAxisSize: MainAxisSize.min,
+          spacing: 16,
+          children: [
+            WdsSquareButton.normal(
+              onTap: () => debugPrint('Normal variant'),
+              child: const Text('텍스트'),
+            ),
+            WdsSquareButton.step(
+              leadingButton: InkWell(
+                onTap: () => debugPrint('Step minus'),
+                child: WdsIcon.minus.build(
+                  color: WdsColors.cta,
+                  width: 16,
+                  height: 16,
+                ),
+              ),
+              trailingButton: InkWell(
+                onTap: () => debugPrint('Step plus'),
+                child: WdsIcon.plus.build(
+                  color: WdsColors.cta,
+                  width: 16,
+                  height: 16,
+                ),
+              ),
               child: const Text('텍스트'),
             ),
           ],


### PR DESCRIPTION
`WdsSquareButton` 컴포넌트에 새로운 `Variant` 을 추가하고, API를 개선하여 명확성과 확장성을 높인 변경 사항을 포함합니다. 
또한 문서와 위젯북 예제를 업데이트하여 새로운 기능을 시각적으로 확인할 수 있도록 했습니다.

🔹 컴포넌트 개선
- `WdsSquareButtonVariant` `enum` 추가
- `Named Constructor` 도입
    - `WdsSquareButton.normal`: 기존 일반 버튼
   - `WdsSquareButton.step`: 앞뒤(`leading`/`trailing`) 버튼이 있는 새 변형 (주로 minus/plus 아이콘 사용)
- 내부 빌드 로직 리팩터링 → 변형(variant)에 따라 레이아웃, 패딩, 자식 배치를 유연하게 처리하도록 개선

🔹 문서 업데이트
- `SquareButton` 섹션에 variant 속성 및 두 가지 변형(`normal`, `step`)의 사용법과 코드 예제 추가
- 각 변형의 속성과 활용 방식을 상세히 설명

🔹 위젯북 개선
- `Playground`에서 `normal` / `step` 변형 선택 가능
- 두 변형의 동작과 속성을 시연할 수 있는 데모 추가