### PR TITLE
Fix: Select 에서 variant 제거 및 state 정리

### DIFF
--- a/packages/components/lib/src/select/wds_select.dart
+++ b/packages/components/lib/src/select/wds_select.dart
@@ -1,7 +1,5 @@
 part of '../../wds_components.dart';
 
-enum WdsSelectVariant { normal, blocked }
-
 /// 드롭다운 Select
 /// - padding: EdgeInsets.fromLTRB(16, 12, 16, 12)
 /// - radius: WdsRadius.sm
@@ -16,19 +14,8 @@ class WdsSelect extends StatefulWidget {
     this.isEnabled = true,
     this.isExpanded = false,
     this.onTap,
-    this.variant = WdsSelectVariant.normal,
     super.key,
   });
-
-  const WdsSelect.blocked({
-    required this.selected,
-    required this.hintText,
-    this.title,
-    this.isEnabled = true,
-    this.isExpanded = false,
-    this.onTap,
-    super.key,
-  }) : variant = WdsSelectVariant.blocked;
 
   /// 좌측 상단 "주제"
   ///
@@ -48,8 +35,6 @@ class WdsSelect extends StatefulWidget {
 
   /// 셀 탭 콜백
   final VoidCallback? onTap;
-
-  final WdsSelectVariant variant;
 
   @override
   State<WdsSelect> createState() => _WdsSelectState();
@@ -89,11 +74,7 @@ class _WdsSelectState extends State<WdsSelect> {
 
     final arrowIcon =
         (widget.isExpanded ? WdsIcon.chevronUp : WdsIcon.chevronDown).build(
-      color: widget.variant == WdsSelectVariant.blocked
-          ? WdsColors.textNeutral.withAlpha(
-              WdsOpacity.opacity40.toAlpha(),
-            )
-          : WdsColors.neutral500,
+      color: widget.isEnabled ? WdsColors.neutral600 : WdsColors.neutral100,
     );
 
     final field = Padding(
@@ -143,18 +124,16 @@ class _WdsSelectState extends State<WdsSelect> {
   }
 
   Color _titleColor() {
-    return (!widget.isEnabled && widget.variant == WdsSelectVariant.blocked)
-        ? WdsColors.textDisable
-        : WdsColors.textNormal;
+    if (!widget.isEnabled) {
+      return WdsColors.textDisable;
+    }
+
+    return WdsColors.textNormal;
   }
 
   Color _textColor() {
     if (!widget.isEnabled) {
       return WdsColors.textDisable;
-    }
-
-    if (widget.variant == WdsSelectVariant.blocked) {
-      return WdsColors.textAlternative;
     }
 
     if (widget.selected?.isEmpty ?? true) {
@@ -165,17 +144,18 @@ class _WdsSelectState extends State<WdsSelect> {
   }
 
   Color _backgroundColor() {
-    return switch (widget.variant) {
-      WdsSelectVariant.normal => WdsColors.white,
-      WdsSelectVariant.blocked => WdsColors.neutral50,
-    };
+    if (!widget.isEnabled) {
+      return WdsColors.neutral50;
+    }
+
+    return WdsColors.white;
   }
 
   BorderSide _borderSide() {
-    return switch (widget.variant) {
-      WdsSelectVariant.normal => const BorderSide(color: WdsColors.primary),
-      WdsSelectVariant.blocked =>
-        const BorderSide(color: WdsColors.borderAlternative),
-    };
+    if (!widget.isEnabled) {
+      return const BorderSide(color: WdsColors.borderAlternative);
+    }
+
+    return const BorderSide(color: WdsColors.primary);
   }
 }

--- a/packages/widgetbook/lib/src/component/select_use_case.dart
+++ b/packages/widgetbook/lib/src/component/select_use_case.dart
@@ -47,20 +47,12 @@ Widget _buildPlaygroundSection(BuildContext context) {
     description: '오른쪽 아이콘이 바뀌어요',
   );
 
-  final variant = context.knobs.object.dropdown<WdsSelectVariant>(
-    label: 'variant',
-    options: WdsSelectVariant.values,
-    initialOption: WdsSelectVariant.normal,
-    labelBuilder: (v) => v.name,
-  );
-
   final select = WdsSelect(
     selected: selected.isEmpty ? null : selected,
     title: title.isEmpty ? null : title,
     hintText: hint,
     isEnabled: enabled,
     isExpanded: expanded,
-    variant: variant,
     onTap: () => debugPrint('Select tapped'),
   );
 
@@ -79,97 +71,53 @@ Widget _buildPlaygroundSection(BuildContext context) {
   );
 }
 
+typedef _SelectState = (
+  String? selected,
+  bool isEnabled,
+  String? title,
+  bool isExpanded,
+);
+
 Widget _buildDemonstrationSection(BuildContext context) {
-  return const WidgetbookSection(
+  List<_SelectState> states = [
+    (null, true, null, false), // inactive
+    ('-0.50', true, null, false), // active
+    ('-0.50', true, null, true), // selected
+    (null, false, null, false), // disabled
+    (null, true, '옵션 선택', false), // inactive
+    ('-0.50', true, '옵션 선택', false), // active
+    ('-0.50', true, '옵션 선택', true), // selected
+    (null, false, '옵션 선택', false), // disabled
+  ];
+
+  return WidgetbookSection(
     title: 'Select',
     children: [
       WidgetbookSubsection(
-        title: 'variant',
-        labels: ['normal', 'blocked'],
-        content: Wrap(
-          spacing: 16,
-          runSpacing: 16,
-          children: [
-            _SelectDemo(variant: WdsSelectVariant.normal, enabled: true),
-            _SelectDemo(variant: WdsSelectVariant.blocked, enabled: true),
-          ],
-        ),
-      ),
-      SizedBox(height: 24),
-      WidgetbookSubsection(
         title: 'state',
-        labels: ['enabled', 'disabled'],
+        labels: ['inactive', 'active', 'selected', 'disabled'],
         content: Wrap(
           spacing: 16,
           runSpacing: 16,
-          children: [
-            _SelectDemo(
-              variant: WdsSelectVariant.normal,
-              enabled: true,
-            ),
-            _SelectDemo(
-              variant: WdsSelectVariant.blocked,
-              enabled: true,
-            ),
-            _SelectDemo(
-              variant: WdsSelectVariant.normal,
-              enabled: false,
-            ),
-            _SelectDemo(
-              variant: WdsSelectVariant.blocked,
-              enabled: false,
-            ),
-            _SelectDemo(
-              variant: WdsSelectVariant.normal,
-              enabled: true,
-              title: '주제',
-            ),
-            _SelectDemo(
-              variant: WdsSelectVariant.blocked,
-              enabled: true,
-              title: '주제',
-            ),
-            _SelectDemo(
-              variant: WdsSelectVariant.normal,
-              enabled: false,
-              title: '주제',
-            ),
-            _SelectDemo(
-              variant: WdsSelectVariant.blocked,
-              enabled: false,
-              title: '주제',
-            ),
-          ],
+          children: states
+              .map(
+                (state) => ConstrainedBox(
+                  constraints: const BoxConstraints(
+                    minWidth: 250,
+                    maxWidth: 320,
+                  ),
+                  child: WdsSelect(
+                    selected: state.$1,
+                    isEnabled: state.$2,
+                    title: state.$3,
+                    isExpanded: state.$4,
+                    hintText: '옵션을 선택해 주세요',
+                  ),
+                ),
+              )
+              .toList(),
         ),
       ),
     ],
   );
-}
-
-class _SelectDemo extends StatelessWidget {
-  const _SelectDemo({
-    required this.variant,
-    required this.enabled,
-    this.title,
-  });
-
-  final WdsSelectVariant variant;
-
-  final bool enabled;
-
-  final String? title;
-
-  @override
-  Widget build(BuildContext context) {
-    return ConstrainedBox(
-      constraints: const BoxConstraints(minWidth: 250, maxWidth: 320),
-      child: WdsSelect(
-        title: title,
-        selected: null,
-        hintText: '옵션을 선택해 주세요',
-        isEnabled: enabled,
-        variant: variant,
-      ),
-    );
-  }
 }


### PR DESCRIPTION
## ✅ 주요 변경 요약

### 1. **컴포넌트 API 단순화**
* `WdsSelectVariant` 열거형 및 `variant` 속성 제거
  * `WdsSelect` 위젯에서 "normal" 및 "blocked" 변형 간 구분 제거
  * 컴포넌트가 이제 `isEnabled` 속성만을 사용하여 상태 및 외관 결정
* 스타일링 로직 통합
  * 제거된 `variant` 대신 `isEnabled`에 의존하도록 색상, 배경, 보더 로직 업데이트
  * 활성 및 비활성 상태에 대한 일관된 스타일링 보장

---

### 2. **Widgetbook 및 데모 업데이트**
* 플레이그라운드 컨트롤 단순화
  * `variant` 속성 및 `WdsSelectVariant` 열거형에 대한 모든 참조 제거
  * 더 깔끔하고 직관적인 컨트롤 인터페이스 제공
* 시연 섹션 리팩토링
  * 다양한 select 상태(활성, 비활성, 선택됨, 비활성화)를 나타내기 위해 상태 튜플 목록 사용
  * `_SelectDemo` 헬퍼 위젯 제거로 코드 간소화

---

## 📋 **주요 변경 포인트**
* **더 깔끔하고 사용하기 쉬운 컴포넌트 API 제공**
* **`isEnabled` 속성 기반의 통합된 상태 관리**
* **불필요한 복잡성 제거로 개발자 경험 향상**
* **간소화된 시연 및 테스트 환경**

---

## ☑️ **마이그레이션/배포 체크리스트**
* `WdsSelect` 컴포넌트가 `isEnabled` 속성만으로 올바른 스타일링을 적용하는지 확인
* 활성 및 비활성 상태에서 색상, 배경, 보더가 일관되게 표시되는지 테스트
* 기존 `variant` 속성을 사용하던 코드가 모두 업데이트되었는지 검증
* Widgetbook 플레이그라운드에서 간소화된 컨트롤이 정상 작동하는지 확인
* 새로운 시연 섹션이 모든 select 상태를 명확하게 보여주는지 테스트
* `WdsSelectVariant` 열거형 제거로 인한 빌드 오류가 없는지 검증
* 비활성화된 select의 사용자 상호작용이 적절히 차단되는지 확인
* 단순화된 API가 기존 사용 사례를 모두 지원하는지 검토


<img width="990" height="446" alt="image" src="https://github.com/user-attachments/assets/e6397a8e-2f5f-45c6-aa97-18bd4a0cfe00" />
