### PR TITLE
Fix: Sheet에서 nudging 제거 및 draggable 여부 설정

### DIFF
--- a/packages/widgetbook/lib/src/component/sheet_use_case.dart
+++ b/packages/widgetbook/lib/src/component/sheet_use_case.dart
@@ -3,6 +3,19 @@ import 'package:wds_widgetbook/src/widgetbook_components/widgetbook_components.d
 import 'package:widgetbook/widgetbook.dart';
 import 'package:widgetbook_annotation/widgetbook_annotation.dart';
 
+const List<Color> blueColors = [
+  WdsColors.blue50,
+  WdsColors.blue100,
+  WdsColors.blue200,
+  WdsColors.blue300,
+  WdsColors.blue400,
+  WdsColors.blue500,
+  WdsColors.blue600,
+  WdsColors.blue700,
+  WdsColors.blue800,
+  WdsColors.blue900,
+];
+
 @UseCase(
   name: 'Sheet',
   type: Sheet,
@@ -23,35 +36,11 @@ Widget buildWdsSheetUseCase(BuildContext context) {
 Widget _buildPlaygroundSection(BuildContext context) {
   const deviceHeight = 768.0;
 
-  const List<Color> blueColors = [
-    WdsColors.blue50,
-    WdsColors.blue100,
-    WdsColors.blue200,
-    WdsColors.blue300,
-    WdsColors.blue400,
-    WdsColors.blue500,
-    WdsColors.blue600,
-    WdsColors.blue700,
-    WdsColors.blue800,
-    WdsColors.blue900,
-  ];
-
   final variant = context.knobs.object.dropdown<WdsSheetVariant>(
     label: 'variant',
-    options: [
-      WdsSheetVariant.fixed,
-      WdsSheetVariant.draggable,
-      WdsSheetVariant.nudging,
-    ],
+    options: WdsSheetVariant.values,
     initialOption: WdsSheetVariant.fixed,
     labelBuilder: (value) => value.name,
-  );
-
-  final size = context.knobs.object.dropdown<String>(
-    label: 'size',
-    options: ['max', 'min'],
-    initialOption: 'max',
-    labelBuilder: (value) => value,
   );
 
   final title = context.knobs.string(
@@ -65,16 +54,9 @@ Widget _buildPlaygroundSection(BuildContext context) {
     initialValue: '메인액션',
   );
 
-  final nudgingImage = context.knobs.boolean(
-    label: 'image(nudging)',
-    description: 'nudging variant에서 사용할 이미지를 선택해 주세요',
-    initialValue: variant == WdsSheetVariant.nudging,
-  );
-
   return WidgetbookPlayground(
     info: [
       'Variant: ${variant.name}',
-      'Size: $size',
       'Title: $title',
       'Action Title: $actionTitle',
     ],
@@ -84,38 +66,17 @@ Widget _buildPlaygroundSection(BuildContext context) {
           child: WdsButton(
             onTap: () => material.showModalBottomSheet(
               context: context,
-              isScrollControlled: variant == WdsSheetVariant.draggable,
+              isScrollControlled: true,
               enableDrag: variant == WdsSheetVariant.draggable,
               backgroundColor: Colors.transparent,
-              builder: (context) => variant == WdsSheetVariant.draggable
-                  ? DraggableScrollableSheet(
-                      initialChildSize: size == 'max'
-                          ? variant.maxHeightRatio
-                          : variant.minHeightRatio,
-                      minChildSize: 0,
-                      builder: (context, scrollController) =>
-                          _buildSheetContent(
-                        context,
-                        variant: variant,
-                        size: size,
-                        title: title,
-                        actionTitle: actionTitle,
-                        nudgingImage: nudgingImage,
-                        blueColors: blueColors,
-                        deviceHeight: deviceHeight,
-                        scrollController: scrollController,
-                      ),
-                    )
-                  : _buildSheetContent(
-                      context,
-                      variant: variant,
-                      size: size,
-                      title: title,
-                      actionTitle: actionTitle,
-                      nudgingImage: nudgingImage,
-                      blueColors: blueColors,
-                      deviceHeight: deviceHeight,
-                    ),
+              builder: (context) => _buildSheetContent(
+                context,
+                variant: variant,
+                title: title,
+                actionTitle: actionTitle,
+                blueColors: blueColors,
+                deviceHeight: deviceHeight,
+              ),
             ),
             size: WdsButtonSize.large,
             child: const Text('Sheet 열기'),
@@ -129,13 +90,10 @@ Widget _buildPlaygroundSection(BuildContext context) {
 Widget _buildSheetContent(
   BuildContext context, {
   required WdsSheetVariant variant,
-  required String size,
   required String title,
   required String actionTitle,
-  required bool nudgingImage,
   required List<Color> blueColors,
   required double deviceHeight,
-  ScrollController? scrollController,
 }) {
   return switch (variant) {
     WdsSheetVariant.fixed => WdsSheet.fixed(
@@ -146,49 +104,20 @@ Widget _buildSheetContent(
         },
         headerTitle: title,
         content: SingleChildScrollView(
-          controller: scrollController,
-          child: ColoredBox(
-            color: WdsColors.statusPositive.withAlpha(25),
-            child: SizedBox(
-              height: size == 'max'
-                  ? variant.maxHeightRatio * deviceHeight
-                  : variant.minHeightRatio * deviceHeight,
-            ),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.stretch,
+            children: _buildBlueColors(),
           ),
         ),
         actionTitle: actionTitle,
       ),
     WdsSheetVariant.draggable => WdsSheet.draggable(
-        headerTitle: title,
-        content: ListView.builder(
-          controller: scrollController,
-          itemCount: blueColors.length,
-          itemExtent: 100,
-          itemBuilder: (context, index) => ColoredBox(
-            color: blueColors[index],
-            child: const SizedBox.expand(),
-          ),
-        ),
-      ),
-    WdsSheetVariant.nudging => WdsSheet.nudging(
-        onClose: () => Navigator.of(context).pop(),
         onAction: () {
           debugPrint('onAction');
-          Navigator.of(context).pop();
         },
         actionTitle: actionTitle,
-        image: nudgingImage
-            ? Container(
-                width: 128,
-                height: 128,
-                color: WdsColors.backgroundAlternative,
-                child: WdsIcon.image.build(
-                  color: WdsColors.borderAlternative,
-                ),
-              )
-            : const SizedBox.shrink(),
-        contentTitle: '여기는 제목 영역이에요\n최대 두 줄로 처리합니다',
-        contentDescription: '현재 상황에 대한 추가 설명을 덧붙여 사용자에게 정보를 명확히 전달합니다.',
+        headerTitle: title,
+        children: _buildBlueColors(),
       ),
   };
 }
@@ -197,11 +126,11 @@ Widget _buildDemonstrationSection(BuildContext context) {
   const size = Size(360, 768);
 
   return WidgetbookSection(
-    title: 'variant',
+    title: 'Sheet',
     children: [
       WidgetbookSubsection(
         title: 'variant',
-        labels: ['fixed', 'draggable', 'nudging'],
+        labels: ['fixed', 'draggable'],
         content: Wrap(
           spacing: 24,
           runSpacing: 24,
@@ -217,8 +146,11 @@ Widget _buildDemonstrationSection(BuildContext context) {
                   debugPrint('onAction');
                 },
                 headerTitle: '텍스트',
-                content: SizedBox(
-                  height: size.height * WdsSheetVariant.fixed.maxHeightRatio,
+                content: SingleChildScrollView(
+                  child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.stretch,
+                    children: _buildBlueColors(),
+                  ),
                 ),
                 actionTitle: '메인액션',
               ),
@@ -228,141 +160,12 @@ Widget _buildDemonstrationSection(BuildContext context) {
             __SheetFrame(
               size: size,
               child: WdsSheet.draggable(
-                headerTitle: '텍스트',
-                content: SizedBox(
-                  height:
-                      size.height * WdsSheetVariant.draggable.maxHeightRatio,
-                ),
-              ),
-            ),
-
-            /// nudging
-            __SheetFrame(
-              size: size,
-              child: WdsSheet.nudging(
-                onClose: () {
-                  debugPrint('onClose');
-                },
                 onAction: () {
                   debugPrint('onAction');
                 },
                 actionTitle: '메인액션',
-                image: Container(
-                  width: 128,
-                  height: 128,
-                  color: WdsColors.backgroundAlternative,
-                  child: WdsIcon.image.build(
-                    color: WdsColors.borderAlternative,
-                  ),
-                ),
-                contentTitle: '여기는 제목 영역이에요\n최대 두 줄로 처리합니다',
-                contentDescription: '현재 상황에 대한 추가 설명을 덧붙여 사용자에게 정보를 명확히 전달합니다.',
-              ),
-            ),
-          ],
-        ),
-      ),
-
-      /// Size
-      WidgetbookSubsection(
-        title: 'size',
-        labels: ['max', 'min'],
-        content: Wrap(
-          spacing: 24,
-          runSpacing: 24,
-          children: [
-            /// fixed
-            __SheetFrame(
-              size: size,
-              child: WdsSheet.fixed(
-                onClose: () {
-                  debugPrint('onClose');
-                },
-                onAction: () {
-                  debugPrint('onAction');
-                },
                 headerTitle: '텍스트',
-                content: SizedBox(
-                  height: size.height * WdsSheetVariant.fixed.maxHeightRatio,
-                ),
-                actionTitle: '메인액션',
-              ),
-            ),
-            __SheetFrame(
-              size: size,
-              child: WdsSheet.fixed(
-                onClose: () {
-                  debugPrint('onClose');
-                },
-                onAction: () {
-                  debugPrint('onAction');
-                },
-                headerTitle: '텍스트',
-                content: SizedBox(
-                  height: size.height * WdsSheetVariant.fixed.minHeightRatio,
-                ),
-                actionTitle: '메인액션',
-              ),
-            ),
-
-            /// draggable
-            __SheetFrame(
-              size: size,
-              child: WdsSheet.draggable(
-                headerTitle: '텍스트',
-                content: SizedBox(
-                  height:
-                      size.height * WdsSheetVariant.draggable.maxHeightRatio,
-                ),
-              ),
-            ),
-            __SheetFrame(
-              size: size,
-              child: WdsSheet.draggable(
-                headerTitle: '텍스트',
-                content: SizedBox(
-                  height:
-                      size.height * WdsSheetVariant.draggable.minHeightRatio,
-                ),
-              ),
-            ),
-
-            /// nudging
-            __SheetFrame(
-              size: size,
-              child: WdsSheet.nudging(
-                onClose: () {
-                  debugPrint('onClose');
-                },
-                onAction: () {
-                  debugPrint('onAction');
-                },
-                actionTitle: '메인액션',
-                image: Container(
-                  width: 128,
-                  height: 128,
-                  color: WdsColors.backgroundAlternative,
-                  child: WdsIcon.image.build(
-                    color: WdsColors.borderAlternative,
-                  ),
-                ),
-                contentTitle: '여기는 제목 영역이에요\n최대 두 줄로 처리합니다',
-                contentDescription: '현재 상황에 대한 추가 설명을 덧붙여 사용자에게 정보를 명확히 전달합니다.',
-              ),
-            ),
-            __SheetFrame(
-              size: size,
-              child: WdsSheet.nudging(
-                onClose: () {
-                  debugPrint('onClose');
-                },
-                onAction: () {
-                  debugPrint('onAction');
-                },
-                actionTitle: '메인액션',
-                image: const SizedBox.shrink(),
-                contentTitle: '여기는 제목 영역이에요\n최대 두 줄로 처리합니다',
-                contentDescription: '현재 상황에 대한 추가 설명을 덧붙여 사용자에게 정보를 명확히 전달합니다.',
+                children: _buildBlueColors(),
               ),
             ),
           ],
@@ -370,6 +173,17 @@ Widget _buildDemonstrationSection(BuildContext context) {
       ),
     ],
   );
+}
+
+List<Widget> _buildBlueColors() {
+  return blueColors
+      .map(
+        (color) => ColoredBox(
+          color: color,
+          child: const SizedBox(height: 100),
+        ),
+      )
+      .toList();
 }
 
 class __SheetFrame extends material.StatelessWidget {


### PR DESCRIPTION
## ✅ 주요 변경 요약

### 1. **Sheet 컴포넌트 API 단순화**
* `nudging` 변형 제거 및 API 간소화
  * `WdsSheetVariant`에서 `nudging` 시트 변형 및 관련 코드 모두 제거
  * `fixed` 및 `draggable` 변형만 유지하여 API 복잡성 감소
  * 관련 생성자, 위젯 로직, 시연 케이스 삭제
* 내부 위젯 구조 정리
  * 불필요한 파라미터(`isActionEnabled` 등) 제거
  * 내부 위젯 이름 변경으로 명확성 향상 (예: `_WdsSheetHeader` → `__SheetHeader`)

---

### 2. **Widgetbook 시연 및 플레이그라운드 업데이트**
* `nudging` 변형 참조 완전 제거
  * 관련 컨트롤, 크기 지정 로직, 시연 케이스 모두 제거
  * `fixed` 및 `draggable` 변형만 선택 및 시연 가능
* 플레이그라운드 및 시연 코드 리팩토링
  * 새로운 `WdsSheet` API 사용하도록 업데이트
  * obsolete 파라미터 및 로직 제거
  * 두 변형 모두에 대한 일관되고 단순화된 인터페이스 보장

---

### 3. **코드 정리 및 일관성 개선**
* 중복 코드 제거 및 통합
  * 색상 정의 통합 및 시연 목적의 중복 코드 제거
  * 더 깔끔하고 유지보수하기 쉬운 코드베이스 구축

---

## 📋 **주요 변경 포인트**
* **단순화된 API로 컴포넌트 사용 및 유지보수 용이성 향상**
* **불필요한 복잡성 제거로 개발자 경험 개선**
* **일관된 인터페이스 제공으로 학습 곡선 감소**
* **코드 정리를 통한 전반적인 코드 품질 향상**

---

## ☑️ **마이그레이션/배포 체크리스트**
* `fixed` 및 `draggable` Sheet 변형이 단순화된 API로 올바르게 작동하는지 확인
* `nudging` 변형을 사용하던 기존 코드가 모두 업데이트되었는지 검증
* 내부 위젯 이름 변경이 컴포넌트 기능에 영향을 주지 않는지 테스트
* Widgetbook에서 두 가지 변형의 플레이그라운드가 정상 작동하는지 확인
* 제거된 파라미터들이 더 이상 참조되지 않는지 검증
* 단순화된 시연 코드가 모든 Sheet 기능을 적절히 보여주는지 테스트
* 색상 정의 통합이 시각적 일관성을 유지하는지 확인
* 리팩토링된 코드가 성능상 이점을 제공하는지 검토