### PR TITLE
Fix: WdsButton >  content : icon 대응

### DIFF
--- a/packages/components/lib/src/button/wds_button.dart
+++ b/packages/components/lib/src/button/wds_button.dart
@@ -57,6 +57,30 @@ class _ButtonTypographyBySize {
   }
 }
 
+class _ButtonIconBySize {
+  const _ButtonIconBySize._();
+
+  static double ofSize(WdsButtonSize size) {
+    return switch (size) {
+      WdsButtonSize.xlarge => 20,
+      WdsButtonSize.large => 20,
+      WdsButtonSize.medium => 16,
+      WdsButtonSize.small => 14,
+      WdsButtonSize.tiny => 14,
+    };
+  }
+
+  static SizedBox ofSpacing(WdsButtonSize size) {
+    return switch (size) {
+      WdsButtonSize.xlarge => const SizedBox(width: 4),
+      WdsButtonSize.large => const SizedBox(width: 4),
+      WdsButtonSize.medium => const SizedBox(width: 4),
+      WdsButtonSize.small => const SizedBox(width: 2),
+      WdsButtonSize.tiny => const SizedBox(width: 2),
+    };
+  }
+}
+
 class _ButtonStyleByVariant {
   const _ButtonStyleByVariant._();
 
@@ -99,15 +123,20 @@ class WdsButton extends StatefulWidget {
     this.isEnabled = true,
     this.variant = WdsButtonVariant.cta,
     this.size = WdsButtonSize.medium,
+    this.icon,
     this.isLoading = false,
     super.key,
-  });
+  }) : assert(
+          icon == null || child is Text,
+          'icon은 자식 위젯이 Text인 경우에만 사용 가능합니다.',
+        );
 
   final VoidCallback? onTap;
   final Widget child;
   final bool isEnabled;
   final WdsButtonVariant variant;
   final WdsButtonSize size;
+  final WdsIcon? icon;
   final bool isLoading;
 
   @override
@@ -207,22 +236,34 @@ class _WdsButtonState extends State<WdsButton>
         data: IconThemeData(color: style.foreground),
         child: Padding(
           padding: padding,
-          child: Text(
-            childText.data ?? '',
-            key: childText.key,
-            style: merged,
-            strutStyle: childText.strutStyle,
-            textAlign: childText.textAlign,
-            textDirection: childText.textDirection,
-            locale: childText.locale,
-            softWrap: childText.softWrap,
-            overflow: childText.overflow,
-            textScaler: childText.textScaler,
-            maxLines: 1, // 스펙: 최대 1줄
-            semanticsLabel: childText.semanticsLabel,
-            textWidthBasis: childText.textWidthBasis,
-            textHeightBehavior: childText.textHeightBehavior,
-            selectionColor: childText.selectionColor,
+          child: Row(
+            children: [
+              if (widget.icon != null) ...[
+                widget.icon!.build(
+                  color: style.foreground,
+                  width: _ButtonIconBySize.ofSize(widget.size),
+                  height: _ButtonIconBySize.ofSize(widget.size),
+                ),
+                _ButtonIconBySize.ofSpacing(widget.size),
+              ],
+              Text(
+                childText.data ?? '',
+                key: childText.key,
+                style: merged,
+                strutStyle: childText.strutStyle,
+                textAlign: childText.textAlign,
+                textDirection: childText.textDirection,
+                locale: childText.locale,
+                softWrap: childText.softWrap,
+                overflow: childText.overflow,
+                textScaler: childText.textScaler,
+                maxLines: 1, // 스펙: 최대 1줄
+                semanticsLabel: childText.semanticsLabel,
+                textWidthBasis: childText.textWidthBasis,
+                textHeightBehavior: childText.textHeightBehavior,
+                selectionColor: childText.selectionColor,
+              ),
+            ],
           ),
         ),
       );

--- a/packages/widgetbook/lib/src/component/button_use_case.dart
+++ b/packages/widgetbook/lib/src/component/button_use_case.dart
@@ -50,6 +50,32 @@ Widget _buildPlaygroundSection(BuildContext context) {
     description: '버튼의 로딩 상태를 정의해요',
   );
 
+  final iconType = context.knobs.object.dropdown<String>(
+    label: 'icon',
+    options: [
+      'none',
+      'plus',
+      'minus',
+      'search',
+      'settings',
+      'close',
+      'info',
+      'download',
+      'share',
+      'cart',
+      'call',
+      'camera',
+      'clock',
+      'star_filled',
+      'chevron_right',
+      'chevron_left',
+      'chevron_up',
+      'chevron_down',
+    ],
+    initialOption: 'none',
+    description: '표시할 아이콘을 선택해요',
+  );
+
   final styleBySize = <String, TextStyle>{
     'xlarge': WdsTypography.body15NormalBold,
     'large': WdsTypography.body15NormalBold,
@@ -77,12 +103,34 @@ Widget _buildPlaygroundSection(BuildContext context) {
     _ => WdsButtonVariant.cta,
   };
 
+  final icon = switch (iconType) {
+    'plus' => WdsIcon.plus,
+    'minus' => WdsIcon.minus,
+    'search' => WdsIcon.search,
+    'settings' => WdsIcon.settings,
+    'close' => WdsIcon.close,
+    'info' => WdsIcon.info,
+    'download' => WdsIcon.download,
+    'share' => WdsIcon.share,
+    'cart' => WdsIcon.cart,
+    'call' => WdsIcon.call,
+    'camera' => WdsIcon.camera,
+    'clock' => WdsIcon.clock,
+    'star_filled' => WdsIcon.starFilled,
+    'chevron_right' => WdsIcon.chevronRight,
+    'chevron_left' => WdsIcon.chevronLeft,
+    'chevron_up' => WdsIcon.chevronUp,
+    'chevron_down' => WdsIcon.chevronDown,
+    'none' || _ => null,
+  };
+
   final button = WdsButton(
     onTap: onTap,
     isEnabled: isEnabled,
     variant: variantValue,
     size: sizeValue,
     isLoading: isLoading,
+    icon: icon,
     child: child,
   );
 
@@ -92,6 +140,7 @@ Widget _buildPlaygroundSection(BuildContext context) {
       'size: $size',
       'state: ${isEnabled ? 'enabled' : 'disabled'}',
       'loading: $isLoading',
+      'icon: $iconType',
     ],
     child: button,
   );
@@ -338,6 +387,45 @@ Widget _buildDemonstrationSection(BuildContext context) {
               isLoading: true,
               variant: WdsButtonVariant.secondary,
               child: const Text('텍스트'),
+            ),
+          ],
+        ),
+      ),
+      WidgetbookSubsection(
+        title: 'icon',
+        labels: ['xlarge', 'large', 'medium', 'small', 'tiny'],
+        content: Row(
+          mainAxisSize: MainAxisSize.min,
+          spacing: 16,
+          children: [
+            WdsButton(
+              onTap: () => debugPrint('xlarge icon pressed'),
+              icon: WdsIcon.blank,
+              size: WdsButtonSize.xlarge,
+              child: const Text('추가'),
+            ),
+            WdsButton(
+              onTap: () => debugPrint('large icon pressed'),
+              icon: WdsIcon.blank,
+              size: WdsButtonSize.large,
+              child: const Text('검색'),
+            ),
+            WdsButton(
+              onTap: () => debugPrint('medium icon pressed'),
+              icon: WdsIcon.blank,
+              child: const Text('설정'),
+            ),
+            WdsButton(
+              onTap: () => debugPrint('small icon pressed'),
+              icon: WdsIcon.blank,
+              size: WdsButtonSize.small,
+              child: const Text('장바구니'),
+            ),
+            WdsButton(
+              onTap: () => debugPrint('tiny icon pressed'),
+              icon: WdsIcon.blank,
+              size: WdsButtonSize.tiny,
+              child: const Text('장바구니'),
             ),
           ],
         ),


### PR DESCRIPTION
## ✅ 요약

`WdsButton` 컴포넌트에 아이콘을 텍스트와 함께 표시할 수 있는 기능을 추가한 내용이에요. 
버튼에 아이콘을 붙일 수 있게 되면서 UI 일관성이 강화되었습니다.

## 📝 주요 변경 사항

### 1. WdsButton 기능 확장
- `icon` 파라미터를 추가하여 텍스트 옆에 아이콘을 표시할 수 있도록 지원
- `child`가 `Text`일 때만 아이콘을 쓸 수 있도록 `assert` 조건 추가
- `_ButtonIconBySize` 헬퍼 클래스를 도입하여 버튼 사이즈별 아이콘 크기와 간격을 자동으로 조정
- 버튼 렌더링 로직을 개선해, 아이콘이 있을 경우 텍스트 앞에 아이콘이 표시되도록 처리

### 2. 위젯북(Widgetbook) 업데이트
- `Playground`에서 아이콘 선택 드롭다운을 제공, 선택한 아이콘을 버튼에 미리보기 가능
- 요약(`summary`) 영역에 선택된 아이콘도 함께 표시되도록 개선
- 새로운 데모 섹션을 추가해, 모든 버튼 크기에서 아이콘 적용 사례를 보여줌