### PR TITLE
Feature: TextArea 추가

### DIFF
--- a/packages/components/lib/src/text_area/wds_text_area.dart
+++ b/packages/components/lib/src/text_area/wds_text_area.dart
@@ -1,0 +1,303 @@
+part of '../../wds_components.dart';
+
+/// 디자인 시스템 TextArea
+class WdsTextArea extends StatefulWidget {
+  const WdsTextArea({
+    required this.label,
+    this.controller,
+    this.focusNode,
+    this.isEnabled = true,
+    this.autofocus = false,
+    this.hintText,
+    this.helperText,
+    this.errorText,
+    this.validator,
+    this.autovalidateMode = AutovalidateMode.disabled,
+    this.onChanged,
+    this.onSubmitted,
+    super.key,
+  });
+
+  final TextEditingController? controller;
+
+  final FocusNode? focusNode;
+
+  final bool isEnabled;
+
+  final bool autofocus;
+
+  final String label;
+
+  /// 힌트 텍스트
+  final String? hintText;
+
+  /// 하단 보조 텍스트 (error 미노출 시)
+  final String? helperText;
+
+  /// 오류 메시지 (우선 노출)
+  final String? errorText;
+
+  final ValueChanged<String>? onChanged;
+
+  final ValueChanged<String>? onSubmitted;
+
+  /// 내부 검증을 위한 validator 및 자동검증 모드
+  final String? Function(String value)? validator;
+
+  final AutovalidateMode autovalidateMode;
+
+  @override
+  State<WdsTextArea> createState() => _WdsTextAreaState();
+}
+
+class _WdsTextAreaState extends State<WdsTextArea> {
+  static const int _$maxLength = 2000;
+  static const double _$maxHeight = 120;
+  static const double _$maxContentHeight = 64;
+
+  late final TextEditingController _controller =
+      widget.controller ?? TextEditingController();
+
+  late final FocusNode _focusNode = widget.focusNode ?? FocusNode();
+
+  // Cache expensive computations - using non-nullable fields to avoid memory overhead
+  TextStyle _inputStyle = const TextStyle();
+  TextStyle _hintStyle = const TextStyle();
+  TextStyle _labelStyle = const TextStyle();
+  TextStyle _helperStyle = const TextStyle();
+  TextStyle _errorStyle = const TextStyle();
+
+  String? _internalErrorText;
+  bool _userInteracted = false;
+
+  @override
+  void initState() {
+    super.initState();
+    _controller.addListener(_onChangedInternal);
+    _focusNode.addListener(_onFocusChanged);
+    _precomputeStyles();
+    // 초기 값 존재 시 즉시 검증 필요할 수 있음
+    _runValidation(force: widget.autovalidateMode == AutovalidateMode.always);
+  }
+
+  @override
+  void dispose() {
+    _controller.removeListener(_onChangedInternal);
+    _focusNode.removeListener(_onFocusChanged);
+    if (widget.controller == null) _controller.dispose();
+    if (widget.focusNode == null) _focusNode.dispose();
+    super.dispose();
+  }
+
+  void _precomputeStyles() {
+    _inputStyle = WdsTypography.body13ReadingRegular;
+    _hintStyle = WdsTypography.body13ReadingRegular;
+    _labelStyle = WdsTypography.body13NormalRegular;
+    _helperStyle = WdsTypography.caption12NormalRegular;
+    _errorStyle = WdsTypography.caption12NormalRegular;
+  }
+
+  void _onChangedInternal() {
+    _userInteracted = true;
+    _runValidation();
+    if (mounted) setState(() {});
+  }
+
+  void _onFocusChanged() {
+    // 포커스를 잃을 때 강제 검증 (disabled 모드에서도 blur 시 검증하도록)
+    if (!_hasFocus) {
+      _runValidation(force: true);
+    }
+    if (mounted) setState(() {});
+  }
+
+  bool get _hasFocus => _focusNode.hasFocus;
+  String? get _effectiveErrorText => widget.errorText?.isNotEmpty == true
+      ? widget.errorText
+      : _internalErrorText;
+  bool get _hasError => _effectiveErrorText?.isNotEmpty == true;
+
+  void _runValidation({bool force = false}) {
+    if (widget.validator == null) return;
+
+    final shouldValidate = switch (widget.autovalidateMode) {
+      AutovalidateMode.disabled => force,
+      AutovalidateMode.always => true,
+      AutovalidateMode.onUserInteraction => _userInteracted,
+      AutovalidateMode.onUnfocus => false,
+    };
+
+    if (!shouldValidate) return;
+
+    _internalErrorText = widget.validator!.call(_controller.text);
+  }
+
+  Widget _buildHelperErrorText() {
+    final hasError = _effectiveErrorText?.isNotEmpty == true;
+    final hasHelper = widget.helperText?.isNotEmpty == true;
+
+    if (hasError) {
+      return Text(
+        _effectiveErrorText!,
+        style: _errorStyle.copyWith(color: WdsColors.statusDestructive),
+        maxLines: 1,
+        overflow: TextOverflow.ellipsis,
+      );
+    }
+
+    if (hasHelper) {
+      return Text(
+        widget.helperText!,
+        style: _helperStyle.copyWith(
+          color: widget.isEnabled
+              ? WdsColors.textAlternative
+              : WdsColors.textDisable,
+        ),
+        maxLines: 1,
+        overflow: TextOverflow.ellipsis,
+      );
+    }
+
+    return const SizedBox.shrink();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    const radius = BorderRadius.all(Radius.circular(WdsRadius.radius8));
+    const noBorder = OutlineInputBorder(
+      borderSide: BorderSide(style: BorderStyle.none, width: 0),
+      borderRadius: BorderRadius.all(Radius.circular(0)),
+    );
+
+    final labelColor =
+        widget.isEnabled ? WdsColors.textNormal : WdsColors.textDisable;
+
+    final inputColor =
+        widget.isEnabled ? WdsColors.textNormal : WdsColors.textDisable;
+
+    final hintColor =
+        !widget.isEnabled ? WdsColors.textDisable : WdsColors.textAlternative;
+
+    final filledColor =
+        widget.isEnabled ? WdsColors.backgroundNormal : WdsColors.neutral50;
+
+    final borderColor = switch ((_hasError, _hasFocus)) {
+      (true, _) => WdsColors.statusDestructive,
+      (false, true) => WdsColors.statusPositive,
+      (false, false) => WdsColors.borderAlternative,
+    };
+
+    final area = RepaintBoundary(
+      child: DecoratedBox(
+        decoration: ShapeDecoration(
+          color: filledColor,
+          shape: RoundedRectangleBorder(
+            borderRadius: radius,
+            side: BorderSide(color: borderColor),
+          ),
+        ),
+        child: SizedBox(
+          height: _$maxHeight,
+          child: Stack(
+            children: [
+              Positioned(
+                left: 16,
+                top: 5,
+                right: 3,
+                bottom: 31,
+                child: TextField(
+                  controller: _controller,
+                  focusNode: _focusNode,
+                  enabled: widget.isEnabled,
+                  autofocus: widget.autofocus,
+                  cursorColor: WdsColors.textNormal,
+                  cursorRadius: const Radius.circular(WdsRadius.radius9999),
+                  scrollPadding: const EdgeInsets.all(3),
+                  textAlignVertical: TextAlignVertical.top,
+                  style: _inputStyle.copyWith(color: inputColor),
+                  onChanged: widget.onChanged,
+                  onSubmitted: widget.onSubmitted,
+                  maxLengthEnforcement:
+                      MaxLengthEnforcement.truncateAfterCompositionEnds,
+                  maxLines: null,
+                  inputFormatters: [
+                    LengthLimitingTextInputFormatter(_$maxLength),
+                  ],
+                  textInputAction: TextInputAction.newline,
+                  keyboardType: TextInputType.multiline,
+                  decoration: InputDecoration(
+                    isDense: true,
+                    isCollapsed: true,
+                    visualDensity: VisualDensity.compact,
+                    contentPadding: const EdgeInsets.only(
+                      top: 8,
+                      bottom: 12,
+                    ),
+                    constraints: const BoxConstraints(
+                      maxHeight: _$maxContentHeight,
+                      minHeight: _$maxContentHeight,
+                    ),
+                    hintText: widget.hintText,
+                    hintStyle: _hintStyle.copyWith(color: hintColor),
+                    border: noBorder,
+                    enabledBorder: noBorder,
+                    focusedBorder: noBorder,
+                    disabledBorder: noBorder,
+                    // filled: filledColor != null,
+                    // fillColor: filledColor,
+                  ),
+                ),
+              ),
+
+              /// COUNTER
+              Positioned(
+                left: 16,
+                bottom: 13,
+                child: ValueListenableBuilder(
+                  valueListenable: _controller,
+                  builder: (_, value, __) {
+                    if (value.text.isEmpty) {
+                      return const SizedBox.shrink();
+                    }
+
+                    return Text(
+                      '${value.text.length.toFormat()}/${_$maxLength.toFormat()}',
+                      style: WdsTypography.body13NormalRegular.copyWith(
+                        color: widget.isEnabled
+                            ? WdsColors.textAssistive
+                            : WdsColors.textDisable,
+                      ),
+                    );
+                  },
+                ),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+
+    return ConstrainedBox(
+      constraints: const BoxConstraints(
+        minWidth: 250,
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        mainAxisSize: MainAxisSize.min,
+        spacing: 8,
+        children: [
+          RepaintBoundary(
+            child: Text(
+              widget.label,
+              style: _labelStyle.copyWith(color: labelColor),
+            ),
+          ),
+          ClipRRect(borderRadius: radius, child: area),
+          // Helper/Error text
+          if (_hasError || widget.helperText?.isNotEmpty == true)
+            RepaintBoundary(child: _buildHelperErrorText()),
+        ],
+      ),
+    );
+  }
+}

--- a/packages/components/lib/src/text_field/wds_text_field.dart
+++ b/packages/components/lib/src/text_field/wds_text_field.dart
@@ -346,7 +346,9 @@ class _WdsTextFieldState extends State<WdsTextField> {
                 if (showClear)
                   GestureDetector(
                     onTap: _clear,
-                    child: WdsIcon.circleClose.build(),
+                    child: WdsIcon.circleCloseFilled.build(
+                      color: WdsColors.neutral200,
+                    ),
                   ),
               ],
             ),

--- a/packages/components/lib/wds_components.dart
+++ b/packages/components/lib/wds_components.dart
@@ -12,7 +12,9 @@ import 'package:flutter/material.dart'
         TextSelectionTheme,
         TextSelectionThemeData,
         CircularProgressIndicator,
-        Colors;
+        Colors,
+        VisualDensity;
+import 'package:flutter/services.dart';
 import 'package:flutter/widgets.dart';
 import 'package:wds_foundation/wds_foundation.dart';
 
@@ -46,6 +48,7 @@ part 'src/snackbar/wds_snackbar.dart';
 part 'src/switch/wds_switch.dart';
 part 'src/tab/wds_tab.dart';
 part 'src/tag/wds_tag.dart';
+part 'src/text_area/wds_text_area.dart';
 part 'src/text_field/wds_search_field.dart';
 part 'src/text_field/wds_text_field.dart';
 part 'src/thumbnail/wds_thumbnail.dart';

--- a/packages/widgetbook/lib/main.directories.g.dart
+++ b/packages/widgetbook/lib/main.directories.g.dart
@@ -70,6 +70,8 @@ import 'package:wds_widgetbook/src/component/tab_use_case.dart'
     as _wds_widgetbook_src_component_tab_use_case;
 import 'package:wds_widgetbook/src/component/tag_use_case.dart'
     as _wds_widgetbook_src_component_tag_use_case;
+import 'package:wds_widgetbook/src/component/text_area_use_case.dart'
+    as _wds_widgetbook_src_component_text_area_use_case;
 import 'package:wds_widgetbook/src/component/text_button_use_case.dart'
     as _wds_widgetbook_src_component_text_button_use_case;
 import 'package:wds_widgetbook/src/component/text_field_use_case.dart'
@@ -333,6 +335,14 @@ final directories = <_widgetbook.WidgetbookNode>[
         useCase: _widgetbook.WidgetbookUseCase(
           name: 'Tag',
           builder: _wds_widgetbook_src_component_tag_use_case.buildTagUseCase,
+        ),
+      ),
+      _widgetbook.WidgetbookLeafComponent(
+        name: 'TextArea',
+        useCase: _widgetbook.WidgetbookUseCase(
+          name: 'TextArea',
+          builder: _wds_widgetbook_src_component_text_area_use_case
+              .buildWdsTextAreaUseCase,
         ),
       ),
       _widgetbook.WidgetbookLeafComponent(

--- a/packages/widgetbook/lib/src/component/text_area_use_case.dart
+++ b/packages/widgetbook/lib/src/component/text_area_use_case.dart
@@ -1,0 +1,129 @@
+import 'package:wds_widgetbook/src/widgetbook_components/widgetbook_components.dart';
+import 'package:widgetbook/widgetbook.dart';
+import 'package:widgetbook_annotation/widgetbook_annotation.dart' as widgetbook;
+
+@widgetbook.UseCase(
+  name: 'TextArea',
+  type: TextArea,
+  path: '[component]/',
+)
+Widget buildWdsTextAreaUseCase(BuildContext context) {
+  return WidgetbookPageLayout(
+    title: 'TextArea',
+    description: '긴 텍스트를 입력할 때 사용합니다.',
+    children: [
+      _buildPlaygroundSection(context),
+      _buildDemonstrationSection(context),
+    ],
+  );
+}
+
+Widget _buildPlaygroundSection(BuildContext context) {
+  final enabled = context.knobs.boolean(
+    label: 'enabled',
+    initialValue: true,
+  );
+
+  final label = context.knobs.string(
+    label: 'label',
+    initialValue: '주제',
+    description: '텍스트 입력란 위에 표시될 label 텍스트를 입력해 주세요',
+  );
+
+  final hint = context.knobs.string(
+    label: 'hint',
+    initialValue: '이름을 입력해 주세요',
+    description: '아무것도 입력되지 않을 때 보여질 텍스트를 입력해 주세요',
+  );
+
+  final helper = context.knobs.string(
+    label: 'helper',
+    initialValue: '비밀번호는 8~16자 이내로 입력해 주세요',
+    description: '텍스트 입력란 아래에 표시될 헬퍼 텍스트를 입력해 주세요',
+  );
+
+  final error = context.knobs.string(
+    label: 'error',
+    description: '텍스트 입력란 아래에 표시될 에러 텍스트를 입력해 주세요. 작성하면 error 상태로 바뀝니다.',
+  );
+
+  final text = context.knobs.string(
+    label: 'initial text',
+    description: '텍스트 입력란에 초기 값을 입력해 주세요',
+  );
+
+  final controller = TextEditingController(text: text);
+
+  final WdsTextArea area = WdsTextArea(
+    isEnabled: enabled,
+    label: label,
+    hintText: hint,
+    helperText: helper,
+    errorText: error,
+    controller: controller,
+  );
+
+  return WidgetbookPlayground(
+    info: [
+      'state: ${enabled ? 'inactive(아무것도 입력되지 않은 상태)' : 'disabled'}',
+      'label: $label',
+      'hint: $hint',
+      if (helper.isNotEmpty) 'helper: $helper',
+      if (error.isNotEmpty) 'error: $error',
+    ],
+    child: SizedBox(width: 360, child: area),
+  );
+}
+
+Widget _buildDemonstrationSection(BuildContext context) {
+  final activeController = TextEditingController(text: '입력된 내용');
+  final errorController = TextEditingController(text: '에러가 발생할 내용');
+
+  return WidgetbookSection(
+    title: 'TextArea',
+    spacing: 32,
+    children: [
+      WidgetbookSubsection(
+        title: 'state',
+        labels: ['inactive', 'active', 'focused', 'error', 'disabled'],
+        content: Wrap(
+          spacing: 24,
+          runSpacing: 24,
+          children: [
+            const SizedBox(
+              width: 320,
+              child: WdsTextArea(label: '주제', hintText: '텍스트를 입력해 주세요'),
+            ),
+            SizedBox(
+              width: 320,
+              child: WdsTextArea(
+                label: '주제',
+                hintText: '텍스트를 입력해 주세요',
+                controller: activeController,
+              ),
+            ),
+            SizedBox(
+              width: 320,
+              child: WdsTextArea(
+                label: '주제',
+                hintText: '텍스트를 입력해 주세요',
+                controller: errorController,
+                validator: (_) => '에러는 이렇게 발생해요',
+              ),
+            ),
+            SizedBox(
+              width: 320,
+              child: WdsTextArea(
+                label: '주제',
+                hintText: '텍스트를 입력해 주세요',
+                helperText: '설명',
+                controller: activeController,
+                isEnabled: false,
+              ),
+            ),
+          ],
+        ),
+      ),
+    ],
+  );
+}

--- a/packages/widgetbook/lib/src/widgetbook_components/widgetbook_components.dart
+++ b/packages/widgetbook/lib/src/widgetbook_components/widgetbook_components.dart
@@ -17,78 +17,80 @@ part 'section.dart';
 part 'theme.dart';
 part 'title.dart';
 
+class ActionArea {}
+
+class Badge {}
+
 class Button {}
-
-class TextButton {}
-
-/// material 에서 Typography 는 hidden 처리
-class Typography {}
-
-class Icon {}
-
-class Cover {}
-
-class ItemCard {}
-
-class SquareButton {}
-
-class IconButton {}
-
-class Header {}
-
-class Heading {}
 
 class BottomNavigation {}
 
-class SearchField {}
-
-class TextField {}
-
-class PaginationDot {}
-
-class PaginationCount {}
+class Checkbox {}
 
 class Chip {}
 
-/// material 의 Tab 과 충돌을 피하기 위해 Tabs 로 명명
-class Tabs {}
+class Circular {}
 
-class Select {}
-
-class ActionArea {}
-
-class Switch {}
-
-class Checkbox {}
-
-class Radio {}
-
-class Toast {}
-
-class Snackbar {}
-
-class Tooltip {}
+class Cover {}
 
 class Divider {}
 
 class DotBadge {}
 
-class SectionMessage {}
+class Header {}
 
-class Badge {}
+class Heading {}
 
-class Sheet {}
+class Icon {}
 
-class Thumbnail {}
+class IconButton {}
 
-class Tag {}
-
-class Option {}
-
-class Circular {}
+class ItemCard {}
 
 class Loading {}
 
 class MenuItem {}
 
+class Option {}
+
+class PaginationCount {}
+
+class PaginationDot {}
+
+class Radio {}
+
+class SearchField {}
+
+class SectionMessage {}
+
 class SegmentedControl {}
+
+class Select {}
+
+class Sheet {}
+
+class Snackbar {}
+
+class SquareButton {}
+
+class Switch {}
+
+class Tab {}
+
+/// material 의 Tab 과 충돌을 피하기 위해 Tabs 로 명명
+class Tabs {}
+
+class Tag {}
+
+class TextArea {}
+
+class TextButton {}
+
+class TextField {}
+
+class Thumbnail {}
+
+class Toast {}
+
+/// material 에서 Typography 는 hidden 처리
+class Typography {}


### PR DESCRIPTION
## ✅ 주요 변경 요약

### 1. **새로운 WdsTextArea 컴포넌트 구현**
* TextArea 위젯 추가
  * `wds_text_area.dart`에 새로운 `WdsTextArea` 위젯 구현
  * 디자인 시스템 스타일, 검증, 헬퍼/에러 텍스트, 문자 수 계산 기능 지원
  * 다중 행 텍스트 입력을 위한 전문화된 컴포넌트 제공

---

### 2. **Widgetbook 통합**
* TextArea 유스케이스 추가
  * `text_area_use_case.dart`에 `WdsTextArea`용 Widgetbook 유스케이스 생성
  * 다양한 상태에 대한 플레이그라운드 및 시연 섹션 포함
* Widgetbook 디렉토리 등록
  * UI에서 접근 가능하도록 Widgetbook 디렉토리 구조 및 import에 새로운 유스케이스 등록

---

### 3. **컴포넌트 라이브러리 업데이트**
* 메인 엔트리포인트 통합
  * `wds_components.dart`에 새로운 `WdsTextArea` 연결
  * 필요한 모든 import 및 part 포함 보장
* 컴포넌트 레지스트리 업데이트
  * `widgetbook_components.dart`에 `TextArea` 클래스 추가로 Widgetbook 타입 안전성 및 문서화 지원

---

### 4. **마이너 개선사항**
* WdsTextField 시각적 일관성 향상
  * clear 버튼에서 특정 색상을 가진 filled close 아이콘 사용으로 더 나은 시각적 일관성 제공

---

## 📋 **주요 변경 포인트**
* **다중 행 텍스트 입력을 위한 전문화된 컴포넌트 추가**
* **완전한 Widgetbook 통합으로 컴포넌트 탐색 및 테스트 지원**
* **디자인 시스템 표준을 따르는 일관된 스타일링 및 기능**
* **개선된 TextField 시각적 세부사항으로 사용자 경험 향상**

---

## ☑️ **마이그레이션/배포 체크리스트**
* `WdsTextArea` 컴포넌트의 검증, 헬퍼/에러 텍스트 기능이 정상 작동하는지 확인
* 문자 수 계산 기능이 정확하게 실시간으로 업데이트되는지 테스트
* Widgetbook에서 TextArea 플레이그라운드가 모든 상태와 옵션을 올바르게 시연하는지 검증
* 새로운 TextArea가 `wds_components.dart`에서 정상적으로 export되고 import 가능한지 확인
* `WdsTextField`의 개선된 clear 버튼이 시각적으로 일관되게 표시되는지 테스트
* TextArea 컴포넌트가 다양한 텍스트 길이와 줄 수에서 적절히 반응하는지 검증
* Widgetbook 디렉토리에서 TextArea 섹션이 올바르게 접근 가능한지 확인
* TextArea의 스타일링이 다른 입력 컴포넌트와 시각적으로 일관되는지 테스트
* 접근성 기능이 TextArea에서 올바르게 구현되었는지 확인
* 다양한 화면 크기에서 TextArea가 적절히 리사이즈되는지 검증

<img width="401" height="200" alt="image" src="https://github.com/user-attachments/assets/90bffb89-69bc-4e66-8c85-bcb576c3c951" />



<img width="1003" height="878" alt="image" src="https://github.com/user-attachments/assets/d86203a0-9240-40ec-ab39-6e272e33a550" />
