### PR TITLE
CLO-9: Add Semantics widget wrapping to all WDS components

### DIFF
--- a/packages/components/lib/src/action_area/wds_action_area.dart
+++ b/packages/components/lib/src/action_area/wds_action_area.dart
@@ -11,6 +11,7 @@ class WdsActionArea extends StatelessWidget {
   WdsActionArea.normal({
     required this.primary,
     this.showBorder = true,
+    this.semanticLabel,
     super.key,
   }) : variant = WdsActionAreaVariant.normal,
        secondary = null,
@@ -23,6 +24,7 @@ class WdsActionArea extends StatelessWidget {
     required this.secondary,
     required this.primary,
     this.showBorder = true,
+    this.semanticLabel,
     super.key,
   }) : variant = WdsActionAreaVariant.filter,
        assert(secondary != null),
@@ -43,6 +45,7 @@ class WdsActionArea extends StatelessWidget {
     required this.secondary,
     required this.primary,
     this.showBorder = true,
+    this.semanticLabel,
     super.key,
   }) : variant = WdsActionAreaVariant.division,
        assert(secondary != null),
@@ -70,6 +73,9 @@ class WdsActionArea extends StatelessWidget {
   /// 상단 경계선 표시 여부
   final bool showBorder;
 
+  /// 접근성을 위한 시맨틱 라벨
+  final String? semanticLabel;
+
   @override
   Widget build(BuildContext context) {
     final Widget content = switch (variant) {
@@ -78,7 +84,10 @@ class WdsActionArea extends StatelessWidget {
       WdsActionAreaVariant.division => _buildDivision(),
     };
 
-    return LayoutBuilder(
+    return Semantics(
+      container: true,
+      label: semanticLabel,
+      child: LayoutBuilder(
       builder: (context, constraints) {
         return SizedBox(
           width: constraints.maxWidth,
@@ -100,6 +109,7 @@ class WdsActionArea extends StatelessWidget {
           ),
         );
       },
+    ),
     );
   }
 

--- a/packages/components/lib/src/badge/wds_badge.dart
+++ b/packages/components/lib/src/badge/wds_badge.dart
@@ -19,6 +19,7 @@ class WdsBadge extends StatelessWidget {
     }
 
     final displayText = _getDisplayText(count);
+    final semanticLabel = '$count개';
 
     final text = Text(
       displayText,
@@ -33,7 +34,9 @@ class WdsBadge extends StatelessWidget {
     );
 
     if (displayText.length > 2) {
-      return DecoratedBox(
+      return Semantics(
+        label: semanticLabel,
+        child: DecoratedBox(
         decoration: const BoxDecoration(
           color: WdsColors.primary,
           borderRadius: BorderRadius.all(Radius.circular(WdsRadius.radius9999)),
@@ -42,10 +45,13 @@ class WdsBadge extends StatelessWidget {
           padding: const EdgeInsets.fromLTRB(4, 2, 4, 2),
           child: text,
         ),
+      ),
       );
     }
 
-    return SizedBox.square(
+    return Semantics(
+      label: semanticLabel,
+      child: SizedBox.square(
       dimension: 16,
       child: DecoratedBox(
         decoration: const ShapeDecoration(
@@ -56,6 +62,7 @@ class WdsBadge extends StatelessWidget {
           child: text,
         ),
       ),
+    ),
     );
   }
 

--- a/packages/components/lib/src/badge/wds_dot_badge.dart
+++ b/packages/components/lib/src/badge/wds_dot_badge.dart
@@ -44,14 +44,16 @@ class WdsDotBadge extends StatelessWidget {
           right: -2,
           bottom: -2,
           left: -2,
-          child: Align(
-            alignment: alignment!,
-            child: SizedBox.square(
-              dimension: size,
-              child: DecoratedBox(
-                decoration: ShapeDecoration(
-                  shape: const CircleBorder(),
-                  color: color ?? WdsColors.orange600,
+          child: ExcludeSemantics(
+            child: Align(
+              alignment: alignment!,
+              child: SizedBox.square(
+                dimension: size,
+                child: DecoratedBox(
+                  decoration: ShapeDecoration(
+                    shape: const CircleBorder(),
+                    color: color ?? WdsColors.orange600,
+                  ),
                 ),
               ),
             ),

--- a/packages/components/lib/src/button/wds_button.dart
+++ b/packages/components/lib/src/button/wds_button.dart
@@ -398,9 +398,20 @@ class _WdsButtonState extends State<WdsButton>
           )
         : coreGesture;
 
+    final String? semanticLabel = widget.child is Text
+        ? (widget.child as Text).data
+        : null;
+
+    Widget result = Semantics(
+      button: true,
+      enabled: widget.isActive,
+      label: semanticLabel,
+      child: gestureChild,
+    );
+
     if (!widget.isActive) {
-      return Opacity(opacity: 0.4, child: gestureChild);
+      return Opacity(opacity: 0.4, child: result);
     }
-    return gestureChild;
+    return result;
   }
 }

--- a/packages/components/lib/src/button/wds_square_button.dart
+++ b/packages/components/lib/src/button/wds_square_button.dart
@@ -183,10 +183,21 @@ class _WdsSquareButtonState extends State<WdsSquareButton>
       child: gestureChild,
     );
 
+    final String? semanticLabel = widget.child is Text
+        ? (widget.child as Text).data
+        : null;
+
+    final Widget semanticResult = Semantics(
+      button: true,
+      enabled: widget.isEnabled,
+      label: semanticLabel,
+      child: result,
+    );
+
     if (!widget.isEnabled) {
-      return Opacity(opacity: 0.4, child: result);
+      return Opacity(opacity: 0.4, child: semanticResult);
     }
-    return result;
+    return semanticResult;
   }
 
   Widget _buildContent() {

--- a/packages/components/lib/src/button/wds_text_button.dart
+++ b/packages/components/lib/src/button/wds_text_button.dart
@@ -275,9 +275,17 @@ class _WdsTextButtonState extends State<WdsTextButton>
       child: gestureChild,
     );
 
-    if (!widget.isEnabled) {
-      return result; // 색상으로 비활성 표현, 투명도 변경 없음
-    }
-    return result;
+    final String? semanticLabel = widget.child is Text
+        ? (widget.child as Text).data
+        : null;
+
+    final Widget semanticResult = Semantics(
+      button: true,
+      enabled: widget.isEnabled,
+      label: semanticLabel,
+      child: result,
+    );
+
+    return semanticResult;
   }
 }

--- a/packages/components/lib/src/checkbox/wds_checkbox.dart
+++ b/packages/components/lib/src/checkbox/wds_checkbox.dart
@@ -19,6 +19,7 @@ class WdsCheckbox extends StatefulWidget {
     required this.value,
     required this.onChanged,
     this.isEnabled = true,
+    this.semanticLabel,
     super.key,
   }) : size = WdsCheckboxSize.small;
 
@@ -26,6 +27,7 @@ class WdsCheckbox extends StatefulWidget {
     required this.value,
     required this.onChanged,
     this.isEnabled = true,
+    this.semanticLabel,
     super.key,
   }) : size = WdsCheckboxSize.medium;
 
@@ -33,6 +35,7 @@ class WdsCheckbox extends StatefulWidget {
   final ValueChanged<bool>? onChanged;
   final bool isEnabled;
   final WdsCheckboxSize size;
+  final String? semanticLabel;
 
   @override
   State<WdsCheckbox> createState() => _WdsCheckboxState();
@@ -116,10 +119,17 @@ class _WdsCheckboxState extends State<WdsCheckbox>
       child: box,
     );
 
+    final Widget semanticBox = Semantics(
+      checked: widget.value,
+      enabled: widget.isEnabled,
+      label: widget.semanticLabel,
+      child: box,
+    );
+
     if (!widget.isEnabled) {
-      return Opacity(opacity: 0.4, child: box);
+      return Opacity(opacity: 0.4, child: semanticBox);
     }
-    return box;
+    return semanticBox;
   }
 }
 

--- a/packages/components/lib/src/chip/wds_chip.dart
+++ b/packages/components/lib/src/chip/wds_chip.dart
@@ -364,6 +364,11 @@ class _WdsChipState extends State<WdsChip> with SingleTickerProviderStateMixin {
       child: gestureChild,
     );
 
-    return result;
+    return Semantics(
+      button: true,
+      selected: isFocused,
+      label: widget.label,
+      child: result,
+    );
   }
 }

--- a/packages/components/lib/src/circular/wds_circular.dart
+++ b/packages/components/lib/src/circular/wds_circular.dart
@@ -17,7 +17,8 @@ class WdsCircular extends StatelessWidget {
   Widget build(BuildContext context) {
     final strokeWidth = size * (3.0 / 28.0);
 
-    return SizedBox.square(
+    return ExcludeSemantics(
+      child: SizedBox.square(
       dimension: size,
       child: CircularProgressIndicator(
         strokeWidth: strokeWidth,
@@ -26,6 +27,7 @@ class WdsCircular extends StatelessWidget {
           color ?? WdsColors.borderNeutral,
         ),
       ),
+    ),
     );
   }
 }

--- a/packages/components/lib/src/divider/wds_divider.dart
+++ b/packages/components/lib/src/divider/wds_divider.dart
@@ -26,16 +26,19 @@ class WdsDivider extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     if (isVertical) {
-      return const SizedBox(
+      return const ExcludeSemantics(
+        child: SizedBox(
         width: 1,
         height: double.infinity,
         child: DecoratedBox(
           decoration: BoxDecoration(color: WdsColors.borderAlternative),
         ),
+      ),
       );
     }
 
-    return switch (variant) {
+    return ExcludeSemantics(
+      child: switch (variant) {
       WdsDividerVariant.normal => const SizedBox(
         width: double.infinity,
         height: 1,
@@ -50,6 +53,7 @@ class WdsDivider extends StatelessWidget {
           decoration: BoxDecoration(color: WdsColors.backgroundAlternative),
         ),
       ),
-    };
+    },
+    );
   }
 }

--- a/packages/components/lib/src/divider/wds_sliver_divider.dart
+++ b/packages/components/lib/src/divider/wds_sliver_divider.dart
@@ -26,16 +26,22 @@ class WdsSliverDivider extends StatelessWidget {
   Widget build(BuildContext context) {
     if (isVertical) {
       return const SliverToBoxAdapter(
-        child: WdsDivider.vertical(),
+        child: ExcludeSemantics(
+          child: WdsDivider.vertical(),
+        ),
       );
     }
 
     return switch (variant) {
       WdsDividerVariant.normal => const SliverToBoxAdapter(
-        child: WdsDivider(),
+        child: ExcludeSemantics(
+          child: WdsDivider(),
+        ),
       ),
       WdsDividerVariant.thick => const SliverToBoxAdapter(
-        child: WdsDivider(variant: WdsDividerVariant.thick),
+        child: ExcludeSemantics(
+          child: WdsDivider(variant: WdsDividerVariant.thick),
+        ),
       ),
     };
   }

--- a/packages/components/lib/src/header/wds_header.dart
+++ b/packages/components/lib/src/header/wds_header.dart
@@ -180,11 +180,15 @@ class WdsHeader extends StatelessWidget implements PreferredSizeWidget {
       ),
     );
 
-    return ColoredBox(
-      color: fixedBackground,
-      child: Padding(
-        padding: EdgeInsets.only(top: statusBarHeight),
-        child: content,
+    return Semantics(
+      container: true,
+      header: true,
+      child: ColoredBox(
+        color: fixedBackground,
+        child: Padding(
+          padding: EdgeInsets.only(top: statusBarHeight),
+          child: content,
+        ),
       ),
     );
   }

--- a/packages/components/lib/src/header/wds_sliver_header.dart
+++ b/packages/components/lib/src/header/wds_sliver_header.dart
@@ -256,11 +256,15 @@ class _WdsSliverHeaderDelegate extends SliverPersistentHeaderDelegate {
       ),
     );
 
-    return ColoredBox(
-      color: WdsHeader.fixedBackground,
-      child: Padding(
-        padding: EdgeInsets.only(top: statusBarHeight),
-        child: headerContent,
+    return Semantics(
+      container: true,
+      header: true,
+      child: ColoredBox(
+        color: WdsHeader.fixedBackground,
+        child: Padding(
+          padding: EdgeInsets.only(top: statusBarHeight),
+          child: headerContent,
+        ),
       ),
     );
   }

--- a/packages/components/lib/src/heading/wds_heading.dart
+++ b/packages/components/lib/src/heading/wds_heading.dart
@@ -84,9 +84,13 @@ class WdsHeading extends StatelessWidget {
       content = titleWidget;
     }
 
-    return Padding(
-      padding: containerPadding,
-      child: content,
+    return Semantics(
+      header: true,
+      label: title,
+      child: Padding(
+        padding: containerPadding,
+        child: content,
+      ),
     );
   }
 }

--- a/packages/components/lib/src/icon/wds_icon_button.dart
+++ b/packages/components/lib/src/icon/wds_icon_button.dart
@@ -6,12 +6,14 @@ class WdsIconButton extends StatefulWidget {
     required this.onTap,
     required this.icon,
     this.isEnabled = true,
+    this.semanticLabel,
     super.key,
   });
 
   final VoidCallback? onTap;
   final Widget icon; // 일반적으로 WdsIcon.xxx.build(width:24,height:24)
   final bool isEnabled;
+  final String? semanticLabel;
 
   @override
   State<WdsIconButton> createState() => _WdsIconButtonState();
@@ -113,9 +115,16 @@ class _WdsIconButtonState extends State<WdsIconButton>
       child: gestureChild,
     );
 
+    final Widget semanticResult = Semantics(
+      button: true,
+      enabled: widget.isEnabled,
+      label: widget.semanticLabel,
+      child: result,
+    );
+
     if (!widget.isEnabled) {
-      return Opacity(opacity: 0.4, child: result);
+      return Opacity(opacity: 0.4, child: semanticResult);
     }
-    return result;
+    return semanticResult;
   }
 }

--- a/packages/components/lib/src/item_card/wds_item_card.dart
+++ b/packages/components/lib/src/item_card/wds_item_card.dart
@@ -295,7 +295,9 @@ class _WdsItemCardState extends State<WdsItemCard> {
 
     if (widget.size == WdsItemCardSize.xlarge ||
         widget.size == WdsItemCardSize.large) {
-      return _VerticalLayout(
+      return Semantics(
+        label: widget.productName,
+        child: _VerticalLayout(
         thumbnail: thumbnailImageWithLensPattern,
         brandName: widget.brandName,
         productName: widget.productName,
@@ -312,10 +314,13 @@ class _WdsItemCardState extends State<WdsItemCard> {
         size: widget.size,
         isSoldOut: widget.isSoldOut,
         productNameMaxLines: widget.productNameMaxLines,
+      ),
       );
     }
 
-    return _HorizontalLayout(
+    return Semantics(
+      label: widget.productName,
+      child: _HorizontalLayout(
       thumbnail: thumbnailImageWithLensPattern,
       brandName: widget.brandName,
       productName: widget.productName,
@@ -330,6 +335,7 @@ class _WdsItemCardState extends State<WdsItemCard> {
       size: widget.size,
       isSoldOut: widget.isSoldOut,
       productNameMaxLines: widget.productNameMaxLines,
+    ),
     );
   }
 }

--- a/packages/components/lib/src/loading/wds_loading.dart
+++ b/packages/components/lib/src/loading/wds_loading.dart
@@ -89,7 +89,8 @@ class _WdsLoadingState extends State<WdsLoading> with TickerProviderStateMixin {
     final double dotSize = _LoadingDotSizeBySize.of(widget.size);
     final double spacing = _LoadingSpacingBySize.of(widget.size);
 
-    return RepaintBoundary(
+    return ExcludeSemantics(
+      child: RepaintBoundary(
       child: Row(
         mainAxisSize: MainAxisSize.min,
         children: List.generate(3, (index) {
@@ -104,6 +105,7 @@ class _WdsLoadingState extends State<WdsLoading> with TickerProviderStateMixin {
           );
         }),
       ),
+    ),
     );
   }
 }

--- a/packages/components/lib/src/menu_item/wds_menu_item.dart
+++ b/packages/components/lib/src/menu_item/wds_menu_item.dart
@@ -128,6 +128,10 @@ class _WdsMenuItemState extends State<WdsMenuItem> {
           )
         : coreGesture;
 
-    return gestureChild;
+    return Semantics(
+      button: true,
+      label: widget.text,
+      child: gestureChild,
+    );
   }
 }

--- a/packages/components/lib/src/navigation/wds_bottom_navigation.dart
+++ b/packages/components/lib/src/navigation/wds_bottom_navigation.dart
@@ -81,7 +81,11 @@ class _BottomNavigationItemWidget extends StatelessWidget {
 
     final icon = isActive ? item.activeIcon : item.inactiveIcon;
 
-    return GestureDetector(
+    return Semantics(
+      button: true,
+      selected: isActive,
+      label: item.label,
+      child: GestureDetector(
       behavior: HitTestBehavior.opaque,
       onTap: onTap,
       child: SizedBox(
@@ -100,6 +104,7 @@ class _BottomNavigationItemWidget extends StatelessWidget {
           ],
         ),
       ),
+    ),
     );
   }
 }

--- a/packages/components/lib/src/option/wds_option.dart
+++ b/packages/components/lib/src/option/wds_option.dart
@@ -80,7 +80,9 @@ class WdsOption extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return RepaintBoundary(
+    return Semantics(
+      label: '옵션 목록',
+      child: RepaintBoundary(
       child: DecoratedBox(
         decoration: _decoration,
         child: Padding(
@@ -88,6 +90,7 @@ class WdsOption extends StatelessWidget {
           child: _buildContent(),
         ),
       ),
+    ),
     );
   }
 

--- a/packages/components/lib/src/pagination/wds_count_pagination.dart
+++ b/packages/components/lib/src/pagination/wds_count_pagination.dart
@@ -60,7 +60,9 @@ class WdsCountPagination extends StatelessWidget {
     final padding = _PaginationCountPaddingBySize.of(size);
     final textStyle = _PaginationCountTextStyleBySize.of(size);
 
-    return Container(
+    return Semantics(
+      label: '$currentPage / $totalPage',
+      child: Container(
       padding: padding,
       decoration: BoxDecoration(
         color: WdsColors.cta.withAlpha(WdsOpacity.opacity80.toAlpha()),
@@ -97,6 +99,7 @@ class WdsCountPagination extends StatelessWidget {
           ),
         ],
       ),
+    ),
     );
   }
 }

--- a/packages/components/lib/src/pagination/wds_dot_pagination.dart
+++ b/packages/components/lib/src/pagination/wds_dot_pagination.dart
@@ -22,13 +22,15 @@ class WdsDotPagination extends StatelessWidget {
         ? WdsColors.textNormal
         : WdsColors.textAssistive;
 
-    return Container(
+    return ExcludeSemantics(
+      child: Container(
       width: 6,
       height: 6,
       decoration: BoxDecoration(
         color: backgroundColor,
         shape: BoxShape.circle,
       ),
+    ),
     );
   }
 }

--- a/packages/components/lib/src/radio/wds_radio.dart
+++ b/packages/components/lib/src/radio/wds_radio.dart
@@ -25,6 +25,7 @@ class WdsRadio<T> extends StatefulWidget {
     required this.groupValue,
     required this.onChanged,
     this.isEnabled = true,
+    this.semanticLabel,
     super.key,
   }) : size = WdsRadioSize.small;
 
@@ -33,6 +34,7 @@ class WdsRadio<T> extends StatefulWidget {
     required this.groupValue,
     required this.onChanged,
     this.isEnabled = true,
+    this.semanticLabel,
     super.key,
   }) : size = WdsRadioSize.large;
 
@@ -49,6 +51,8 @@ class WdsRadio<T> extends StatefulWidget {
   final bool isEnabled;
 
   final WdsRadioSize size;
+
+  final String? semanticLabel;
 
   /// 현재 이 Radio가 선택된 상태인지 확인
   bool get isSelected => value == groupValue;
@@ -98,11 +102,18 @@ class _WdsRadioState<T> extends State<WdsRadio<T>> {
       child: radio,
     );
 
+    final Widget semanticRadio = Semantics(
+      selected: widget.isSelected,
+      enabled: widget.isEnabled,
+      label: widget.semanticLabel,
+      child: radio,
+    );
+
     if (!widget.isEnabled) {
-      return Opacity(opacity: 0.4, child: radio);
+      return Opacity(opacity: 0.4, child: semanticRadio);
     }
 
-    return radio;
+    return semanticRadio;
   }
 }
 

--- a/packages/components/lib/src/section_message/wds_section_message.dart
+++ b/packages/components/lib/src/section_message/wds_section_message.dart
@@ -76,7 +76,9 @@ class WdsSectionMessage extends StatelessWidget {
   Widget build(BuildContext context) {
     final style = _SectionMessageStyleByVariant.of(variant);
 
-    return DecoratedBox(
+    return Semantics(
+      label: message,
+      child: DecoratedBox(
       decoration: BoxDecoration(
         color: style.background,
         borderRadius: const BorderRadius.all(Radius.circular(8)),
@@ -101,6 +103,7 @@ class WdsSectionMessage extends StatelessWidget {
           ],
         ),
       ),
+    ),
     );
   }
 }

--- a/packages/components/lib/src/segmented_control/wds_segmented_control.dart
+++ b/packages/components/lib/src/segmented_control/wds_segmented_control.dart
@@ -38,7 +38,9 @@ class _WdsSegmentedControlState extends State<WdsSegmentedControl> {
       return const SizedBox.shrink();
     }
 
-    return LayoutBuilder(
+    return Semantics(
+      label: widget.segments[widget.selectedIndex],
+      child: LayoutBuilder(
       builder: (context, constraints) {
         final width = constraints.maxWidth > 0 ? constraints.maxWidth : 108.0;
         final segmentWidth = width / widget.segments.length;
@@ -116,6 +118,7 @@ class _WdsSegmentedControlState extends State<WdsSegmentedControl> {
           ),
         );
       },
+    ),
     );
   }
 }

--- a/packages/components/lib/src/select/wds_select.dart
+++ b/packages/components/lib/src/select/wds_select.dart
@@ -115,6 +115,10 @@ class WdsSelect extends StatelessWidget {
       child: GestureDetector(onTap: onTap, child: column),
     );
 
-    return result;
+    return Semantics(
+      button: true,
+      label: title ?? selected ?? hintText,
+      child: result,
+    );
   }
 }

--- a/packages/components/lib/src/sheet/wds_sheet.dart
+++ b/packages/components/lib/src/sheet/wds_sheet.dart
@@ -47,6 +47,7 @@ abstract class WdsSheet extends StatelessWidget {
     this.backgroundColor = WdsColors.white,
     this.header,
     this.actionArea,
+    this.semanticLabel,
     super.key,
   });
 
@@ -55,12 +56,14 @@ abstract class WdsSheet extends StatelessWidget {
     Widget? header,
     Widget? actionArea,
     Color backgroundColor = WdsColors.white,
+    String? semanticLabel,
     Key? key,
   }) => _FixedSheet(
     backgroundColor: backgroundColor,
     header: header,
     content: content,
     actionArea: actionArea,
+    semanticLabel: semanticLabel,
     key: key,
   );
 
@@ -69,11 +72,13 @@ abstract class WdsSheet extends StatelessWidget {
     Widget? header,
     Widget? actionArea,
     Color backgroundColor = WdsColors.white,
+    String? semanticLabel,
     Key? key,
   }) => _DraggableSheet(
     backgroundColor: backgroundColor,
     header: header,
     actionArea: actionArea,
+    semanticLabel: semanticLabel,
     key: key,
     children: children,
   );
@@ -82,6 +87,7 @@ abstract class WdsSheet extends StatelessWidget {
   final Color backgroundColor;
   final Widget? header;
   final Widget? actionArea;
+  final String? semanticLabel;
 }
 
 class _FixedSheet extends WdsSheet {
@@ -90,6 +96,7 @@ class _FixedSheet extends WdsSheet {
     super.backgroundColor = WdsColors.white,
     super.header,
     super.actionArea,
+    super.semanticLabel,
     super.key,
   }) : super(variant: WdsSheetVariant.fixed);
 
@@ -97,32 +104,36 @@ class _FixedSheet extends WdsSheet {
 
   @override
   Widget build(BuildContext context) {
-    return __SheetContainer(
-      variant: variant,
-      backgroundColor: backgroundColor,
-      child: Column(
-        crossAxisAlignment: CrossAxisAlignment.stretch,
-        mainAxisSize: MainAxisSize.min,
-        children: [
-          if (header != null)
-            RepaintBoundary(
-              child: __SheetHeader(
-                header: header!,
-              ),
-            )
-          else
-            const SizedBox(height: 12),
-          Padding(
-            padding: _SheetPaddingByArea.view,
-            child: content,
-          ),
-          if (actionArea != null)
-            RepaintBoundary(
-              child: __SheetBottom(
-                actionArea: actionArea!,
-              ),
+    return Semantics(
+      container: true,
+      label: semanticLabel,
+      child: __SheetContainer(
+        variant: variant,
+        backgroundColor: backgroundColor,
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.stretch,
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            if (header != null)
+              RepaintBoundary(
+                child: __SheetHeader(
+                  header: header!,
+                ),
+              )
+            else
+              const SizedBox(height: 12),
+            Padding(
+              padding: _SheetPaddingByArea.view,
+              child: content,
             ),
-        ],
+            if (actionArea != null)
+              RepaintBoundary(
+                child: __SheetBottom(
+                  actionArea: actionArea!,
+                ),
+              ),
+          ],
+        ),
       ),
     );
   }
@@ -134,6 +145,7 @@ class _DraggableSheet extends WdsSheet {
     super.backgroundColor = WdsColors.white,
     super.header,
     super.actionArea,
+    super.semanticLabel,
     super.key,
   }) : super(
          variant: WdsSheetVariant.draggable,
@@ -149,7 +161,10 @@ class _DraggableSheet extends WdsSheet {
         ? WdsColors.white
         : backgroundColor;
 
-    return DraggableScrollableSheet(
+    return Semantics(
+      container: true,
+      label: semanticLabel,
+      child: DraggableScrollableSheet(
       initialChildSize: variant.initialHeightRatio,
       maxChildSize: variant.maxHeightRatio,
       builder: (context, scrollController) {
@@ -195,6 +210,7 @@ class _DraggableSheet extends WdsSheet {
           ),
         );
       },
+    ),
     );
   }
 }

--- a/packages/components/lib/src/skeleton/wds_skeleton.dart
+++ b/packages/components/lib/src/skeleton/wds_skeleton.dart
@@ -54,7 +54,8 @@ class _WdsSkeletonState extends State<WdsSkeleton>
   Widget build(BuildContext context) {
     // RepaintBoundary는 쉬머 애니메이션을 분리하여 부모 위젯의 리페인트를 방지하는 데
     // 사용됩니다.
-    return RepaintBoundary(
+    return ExcludeSemantics(
+      child: RepaintBoundary(
       child: Padding(
         padding: widget._padding,
         child: AnimatedBuilder(
@@ -80,6 +81,7 @@ class _WdsSkeletonState extends State<WdsSkeleton>
           ),
         ),
       ),
+    ),
     );
   }
 }

--- a/packages/components/lib/src/slider/wds_slider.dart
+++ b/packages/components/lib/src/slider/wds_slider.dart
@@ -38,6 +38,7 @@ class WdsSlider extends StatefulWidget {
     required this.onChanged,
     this.hasTitle = false,
     this.isEnabled = true,
+    this.semanticLabel,
     super.key,
   });
 
@@ -61,6 +62,9 @@ class WdsSlider extends StatefulWidget {
 
   /// 활성화 상태
   final bool isEnabled;
+
+  /// 접근성을 위한 시맨틱 라벨
+  final String? semanticLabel;
 
   @override
   State<WdsSlider> createState() => _WdsSliderState();
@@ -303,7 +307,15 @@ class _WdsSliderState extends State<WdsSlider> {
       onTrackTap: _handleRangeChanged,
     );
 
-    if (!widget.hasTitle) return sliderTrack;
+    final Widget semanticSlider = Semantics(
+      slider: true,
+      enabled: widget.isEnabled,
+      label: widget.semanticLabel,
+      value: '${widget.values.start} - ${widget.values.end}',
+      child: sliderTrack,
+    );
+
+    if (!widget.hasTitle) return semanticSlider;
 
     return Column(
       spacing: 12,
@@ -313,7 +325,7 @@ class _WdsSliderState extends State<WdsSlider> {
           start: widget.values.start,
           end: widget.values.end,
         ),
-        sliderTrack,
+        semanticSlider,
       ],
     );
   }

--- a/packages/components/lib/src/snackbar/wds_snackbar.dart
+++ b/packages/components/lib/src/snackbar/wds_snackbar.dart
@@ -58,14 +58,18 @@ class WdsSnackbar extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return DecoratedBox(
-      decoration: const BoxDecoration(
-        color: WdsColors.cta,
-        borderRadius: BorderRadius.all(Radius.circular(8)),
-      ),
-      child: Padding(
-        padding: const EdgeInsets.fromLTRB(16, 9, 16, 9),
-        child: _buildRow(),
+    return Semantics(
+      liveRegion: true,
+      label: description != null ? '$message $description' : message,
+      child: DecoratedBox(
+        decoration: const BoxDecoration(
+          color: WdsColors.cta,
+          borderRadius: BorderRadius.all(Radius.circular(8)),
+        ),
+        child: Padding(
+          padding: const EdgeInsets.fromLTRB(16, 9, 16, 9),
+          child: _buildRow(),
+        ),
       ),
     );
   }

--- a/packages/components/lib/src/switch/wds_switch.dart
+++ b/packages/components/lib/src/switch/wds_switch.dart
@@ -23,6 +23,7 @@ class WdsSwitch extends StatefulWidget {
     required this.value,
     required this.onChanged,
     this.isEnabled = true,
+    this.semanticLabel,
     super.key,
   }) : size = WdsSwitchSize.small;
 
@@ -30,6 +31,7 @@ class WdsSwitch extends StatefulWidget {
     required this.value,
     required this.onChanged,
     this.isEnabled = true,
+    this.semanticLabel,
     super.key,
   }) : size = WdsSwitchSize.large;
 
@@ -40,6 +42,8 @@ class WdsSwitch extends StatefulWidget {
   final bool isEnabled;
 
   final WdsSwitchSize size;
+
+  final String? semanticLabel;
 
   @override
   State<WdsSwitch> createState() => _WdsSwitchState();
@@ -98,10 +102,17 @@ class _WdsSwitchState extends State<WdsSwitch> {
       child: result,
     );
 
+    final Widget semanticResult = Semantics(
+      toggled: widget.value,
+      enabled: widget.isEnabled,
+      label: widget.semanticLabel,
+      child: result,
+    );
+
     if (!widget.isEnabled) {
-      return Opacity(opacity: 0.4, child: result);
+      return Opacity(opacity: 0.4, child: semanticResult);
     }
 
-    return result;
+    return semanticResult;
   }
 }

--- a/packages/components/lib/src/tab/wds_material_tab.dart
+++ b/packages/components/lib/src/tab/wds_material_tab.dart
@@ -50,7 +50,9 @@ class _WdsMaterialTextTabBarState extends State<WdsMaterialTextTabBar> {
     final tabs = widget.tabs;
     final controller = widget.controller!;
 
-    return SizedBox(
+    return Semantics(
+      container: true,
+      child: SizedBox(
       height: 38,
       child: TabBar(
         controller: controller,
@@ -79,6 +81,7 @@ class _WdsMaterialTextTabBarState extends State<WdsMaterialTextTabBar> {
         unselectedLabelStyle: WdsTypography.body15NormalMedium.copyWith(
           color: WdsColors.textAlternative,
         ),
+      ),
       ),
     );
   }

--- a/packages/components/lib/src/tab/wds_tab.dart
+++ b/packages/components/lib/src/tab/wds_tab.dart
@@ -253,9 +253,13 @@ class WdsTextTab extends StatelessWidget with WdsBadgeMixin {
     }
 
     // WdsBadgeMixin의 addDotBadge 메서드로 배지 기능 추가
-    return buildWidgetWithDotBadge(
+    return Semantics(
+      label: label,
+      selected: isSelected,
+      child: buildWidgetWithDotBadge(
       child: textWidget,
       alignment: badgeAlignment,
+    ),
     );
   }
 }

--- a/packages/components/lib/src/tag/wds_tag.dart
+++ b/packages/components/lib/src/tag/wds_tag.dart
@@ -135,7 +135,9 @@ class WdsTag extends StatelessWidget {
       child = label;
     }
 
-    return SizedBox(
+    return Semantics(
+      label: this.label,
+      child: SizedBox(
       height: fixedHeight,
       child: DecoratedBox(
         decoration: BoxDecoration(
@@ -147,6 +149,7 @@ class WdsTag extends StatelessWidget {
           child: child,
         ),
       ),
+    ),
     );
   }
 }

--- a/packages/components/lib/src/text_area/wds_text_area.dart
+++ b/packages/components/lib/src/text_area/wds_text_area.dart
@@ -202,7 +202,10 @@ class _WdsTextAreaState extends State<WdsTextArea> {
       ),
     );
 
-    return ConstrainedBox(
+    return Semantics(
+      textField: true,
+      label: widget.label.data ?? widget.hintText,
+      child: ConstrainedBox(
       constraints: const BoxConstraints(
         minWidth: 250,
       ),
@@ -241,6 +244,7 @@ class _WdsTextAreaState extends State<WdsTextArea> {
           ),
         ],
       ),
+    ),
     );
   }
 }

--- a/packages/components/lib/src/text_field/wds_search_field.dart
+++ b/packages/components/lib/src/text_field/wds_search_field.dart
@@ -194,7 +194,10 @@ class _WdsSearchFieldState extends State<WdsSearchField> {
       ),
     );
 
-    return ClipRRect(
+    return Semantics(
+      textField: true,
+      label: widget.hintText,
+      child: ClipRRect(
       borderRadius: borderRadius,
       child: ConstrainedBox(
         constraints: BoxConstraints(
@@ -204,6 +207,7 @@ class _WdsSearchFieldState extends State<WdsSearchField> {
         ),
         child: core,
       ),
+    ),
     );
   }
 }

--- a/packages/components/lib/src/text_field/wds_text_field.dart
+++ b/packages/components/lib/src/text_field/wds_text_field.dart
@@ -226,10 +226,14 @@ class _WdsTextFieldState extends State<WdsTextField> {
 
   @override
   Widget build(BuildContext context) {
-    return switch (widget.variant) {
-      WdsTextFieldVariant.outlined => _buildOutlined(context),
-      WdsTextFieldVariant.box => _buildBox(context),
-    };
+    return Semantics(
+      textField: true,
+      label: widget.label ?? widget.hintText,
+      child: switch (widget.variant) {
+        WdsTextFieldVariant.outlined => _buildOutlined(context),
+        WdsTextFieldVariant.box => _buildBox(context),
+      },
+    );
   }
 
   Widget _buildOutlined(BuildContext context) {

--- a/packages/components/lib/src/thumbnail/wds_thumbnail.dart
+++ b/packages/components/lib/src/thumbnail/wds_thumbnail.dart
@@ -25,6 +25,7 @@ class WdsThumbnail extends StatelessWidget {
     required this.size,
     this.hasRadius = false,
     this.scaleFactor = 1,
+    this.semanticLabel,
     super.key,
   });
 
@@ -32,6 +33,7 @@ class WdsThumbnail extends StatelessWidget {
     required this.imagePath,
     this.hasRadius = false,
     this.scaleFactor = 1,
+    this.semanticLabel,
     super.key,
   }) : size = WdsThumbnailSize.xxsmall;
 
@@ -39,6 +41,7 @@ class WdsThumbnail extends StatelessWidget {
     required this.imagePath,
     this.hasRadius = false,
     this.scaleFactor = 1,
+    this.semanticLabel,
     super.key,
   }) : size = WdsThumbnailSize.xsmall;
 
@@ -46,6 +49,7 @@ class WdsThumbnail extends StatelessWidget {
     required this.imagePath,
     this.hasRadius = false,
     this.scaleFactor = 1,
+    this.semanticLabel,
     super.key,
   }) : size = WdsThumbnailSize.small;
 
@@ -53,6 +57,7 @@ class WdsThumbnail extends StatelessWidget {
     required this.imagePath,
     this.hasRadius = false,
     this.scaleFactor = 1,
+    this.semanticLabel,
     super.key,
   }) : size = WdsThumbnailSize.medium;
 
@@ -60,6 +65,7 @@ class WdsThumbnail extends StatelessWidget {
     required this.imagePath,
     this.hasRadius = false,
     this.scaleFactor = 1,
+    this.semanticLabel,
     super.key,
   }) : size = WdsThumbnailSize.large;
 
@@ -67,6 +73,7 @@ class WdsThumbnail extends StatelessWidget {
     required this.imagePath,
     this.hasRadius = false,
     this.scaleFactor = 1,
+    this.semanticLabel,
     super.key,
   }) : size = WdsThumbnailSize.xlarge;
 
@@ -74,6 +81,7 @@ class WdsThumbnail extends StatelessWidget {
     required this.imagePath,
     this.hasRadius = false,
     this.scaleFactor = 1,
+    this.semanticLabel,
     super.key,
   }) : size = WdsThumbnailSize.xxlarge;
 
@@ -89,6 +97,9 @@ class WdsThumbnail extends StatelessWidget {
   final bool hasRadius;
 
   final double scaleFactor;
+
+  /// 접근성을 위한 시맨틱 라벨
+  final String? semanticLabel;
 
   @override
   Widget build(BuildContext context) {
@@ -113,7 +124,11 @@ class WdsThumbnail extends StatelessWidget {
           : imageWidget,
     );
 
-    return RepaintBoundary(child: sizedWidget);
+    return Semantics(
+      image: true,
+      label: semanticLabel,
+      child: RepaintBoundary(child: sizedWidget),
+    );
   }
 
   /// 네트워크 이미지인지 확인

--- a/packages/components/lib/src/toast/wds_toast.dart
+++ b/packages/components/lib/src/toast/wds_toast.dart
@@ -38,14 +38,18 @@ class WdsToast extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return DecoratedBox(
-      decoration: const BoxDecoration(
-        color: WdsColors.cta,
-        borderRadius: BorderRadius.all(Radius.circular(8)),
-      ),
-      child: Padding(
-        padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 9),
-        child: _buildContent(),
+    return Semantics(
+      liveRegion: true,
+      label: message,
+      child: DecoratedBox(
+        decoration: const BoxDecoration(
+          color: WdsColors.cta,
+          borderRadius: BorderRadius.all(Radius.circular(8)),
+        ),
+        child: Padding(
+          padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 9),
+          child: _buildContent(),
+        ),
       ),
     );
   }

--- a/packages/components/lib/src/tooltip/wds_tooltip.dart
+++ b/packages/components/lib/src/tooltip/wds_tooltip.dart
@@ -95,7 +95,9 @@ class WdsTooltip extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return CustomPaint(
+    return Semantics(
+      label: label.data,
+      child: CustomPaint(
       painter: _TooltipPainter(
         hasArrow: hasArrow,
         alignment: alignment,
@@ -119,6 +121,7 @@ class WdsTooltip extends StatelessWidget {
           ),
         ),
       ),
+    ),
     );
   }
 

--- a/packages/components/pubspec.yaml
+++ b/packages/components/pubspec.yaml
@@ -1,5 +1,5 @@
 name: wds_components
-version: 0.0.14
+version: 0.0.18
 publish_to: none
 description: WINC Design System components package
 environment:

--- a/packages/foundation/pubspec.yaml
+++ b/packages/foundation/pubspec.yaml
@@ -1,5 +1,5 @@
 name: wds_foundation
-version: 0.1.0
+version: 0.0.18
 publish_to: none
 description: WINC Design System foundation package
 environment:

--- a/packages/tokens/pubspec.yaml
+++ b/packages/tokens/pubspec.yaml
@@ -1,5 +1,5 @@
 name: wds_tokens
-version: 0.1.0
+version: 0.0.18
 publish_to: none
 description: WINC Design System tokens package
 environment:

--- a/packages/widgetbook/pubspec.yaml
+++ b/packages/widgetbook/pubspec.yaml
@@ -1,5 +1,5 @@
 name: wds_widgetbook
-version: 0.1.0
+version: 0.0.18
 publish_to: "none"
 description: WINC Design System widgetbook package
 environment:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: wds
-version: 0.0.17
+version: 0.0.18
 publish_to: none
 description: WINC Design System
 environment:


### PR DESCRIPTION
## CLO-9: Add Semantics widget wrapping to all WDS components

WDS Flutter 디자인 시스템의 모든 커스텀 위젯에 Flutter `Semantics` 위젯을 적용해서 접근성(a11y)을 확보한다.

**원칙:**

* 컴포넌트에 이미 존재하는 `label`, `message`, `title`, `hintText` 등의 문자열 파라미터를 `Semantics`의 `label`로 최대한 재활용할 것
* 기존 파라미터가 없는 위젯(WdsIconButton, WdsThumbnail, WdsCheckbox 등)에는 `semanticLabel` 옵셔널 파라미터를 새로 추가할 것
* 장식적/구조적 위젯(WdsDivider, WdsSkeleton 등)은 `excludeSemantics: true`로 스크린 리더에서 제외할 것

**범위:** `packages/components/lib/src/` 하위 39개 위젯 전체

---

🔗 **Linear 티켓**: [CLO-9](https://linear.app/ppb/issue/CLO-9/add-semantics-widget-wrapping-to-all-wds-components)

> 이 PR은 Colony 에이전트에 의해 자동으로 생성되었습니다.